### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 pkg/
 wasm-pack.log
 .idea
+# Hidden mac file storing attributes of the directory
+.DS_Store


### PR DESCRIPTION
.DS_Store is a commonly auto-generated hidden file in MacOS directories. Without ignoring them, they show up in the diff to be staged & committed.