### PR TITLE
Sprt web add scattered leapers + some improvement

### DIFF
--- a/sprt/web/main.js
+++ b/sprt/web/main.js
@@ -844,7 +844,7 @@ async function runSprt() {
     }
     CONFIG.minGames = parseInt(sprtMinGames.value, 10) || 500;
     const maxGamesVal = (sprtMaxGames.value || '').trim().toLowerCase();
-    CONFIG.maxGames = (maxGamesVal === 'unlimited' || maxGamesVal === '') ? null : (Number.isFinite(parseInt(maxGamesVal, 10)) ? parseInt(maxGamesVal, 10) : null);
+    CONFIG.maxGames = (maxGamesVal === 'unlimited' || maxGamesVal === '') ? Infinity : (Number.isFinite(parseInt(maxGamesVal, 10)) ? parseInt(maxGamesVal, 10) : Infinity);
     const valMoves = parseInt(sprtMaxMoves.value, 10);
     CONFIG.maxMoves = (Number.isFinite(valMoves) && valMoves > 0) ? valMoves : Infinity;
     {

--- a/sprt/web/variants.js
+++ b/sprt/web/variants.js
@@ -122,6 +122,13 @@ const VARIANTS = {
         worldBorder: 0,
         hasCustomEval: true,
     },
+    // Custom variant that uses all fairy leapers
+    Scattered_Leapers: {
+        position: 'P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P7,2+|P8,2+|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|R1,1+|r1,8+|r8,8+|B3,1|B6,1|b3,8|b6,8|GU2,1|gu2,8|K5,1+|k5,8+|gu7,8|P11,1+|P-2,1+|P-5,0+|P14,0+|p-2,8+|p-5,9+|p11,8+|p14,9+|nr4,9|NR4,0|CA9,-2|ca9,11|ca0,11|ze-3,12|ze12,12|ZE12,-3|GI-5,-6|GI14,-6|gi14,15|gi-5,15|ha-1,14|ha10,14|P6,2+|RO7,-6|p8,7+|ZE-3,-3|CA0,-2|GU7,1|R8,1+|HA10,-5|HA-1,-5|ro7,15',
+        game_rules: {
+            promotions_allowed: ['q', 'r', 'b', 'n'],
+        },
+    },
 };
 
 // Get variant position and special rights

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -702,7 +702,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         // Tropism sums across all royals
                                         if piece_val > 0 {
                                             let d = dx.max(dy);
-                                            w_attacking_tropism += piece_val / (d as i32 + 5);
+                                            w_attacking_tropism += piece_val / (d as i32 + 10);
                                         }
                                     }
                                     // Single pass through WHITE royals for friendly tropism
@@ -710,7 +710,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         for &wk in white_royals {
                                             let d = (x - wk.x).abs().max((y - wk.y).abs());
                                             w_defensive_tropism +=
-                                                piece_val.min(350) / (d as i32 + 5);
+                                                piece_val.min(350) / (d as i32 + 10);
                                         }
                                     }
                                 } else {
@@ -728,7 +728,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         // Tropism sums across all royals
                                         if piece_val > 0 {
                                             let d = dx.max(dy);
-                                            b_attacking_tropism += piece_val / (d as i32 + 5);
+                                            b_attacking_tropism += piece_val / (d as i32 + 10);
                                         }
                                     }
                                     // Single pass through BLACK royals for friendly tropism
@@ -736,7 +736,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         for &bk in black_royals {
                                             let d = (x - bk.x).abs().max((y - bk.y).abs());
                                             b_defensive_tropism +=
-                                                piece_val.min(350) / (d as i32 + 5);
+                                                piece_val.min(350) / (d as i32 + 10);
                                         }
                                     }
                                 }

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -581,6 +581,24 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                         white_rq.clear();
                         black_rq.clear();
 
+                        // Slider counts
+                        for (_cx, _cy, tile) in game.board.tiles.iter() {
+                            if crate::simd::both_zero(tile.occ_white, tile.occ_black) {
+                                continue;
+                            }
+
+                            // Count diagonals and orthogonals directly from bitboards
+                            let w_diag_bits = tile.occ_diag_sliders & tile.occ_white;
+                            let b_diag_bits = tile.occ_diag_sliders & tile.occ_black;
+                            let w_ortho_bits = tile.occ_ortho_sliders & tile.occ_white;
+                            let b_ortho_bits = tile.occ_ortho_sliders & tile.occ_black;
+
+                            w_diag_count += w_diag_bits.count_ones() as i32;
+                            b_diag_count += b_diag_bits.count_ones() as i32;
+                            w_ortho_count += w_ortho_bits.count_ones() as i32;
+                            b_ortho_count += b_ortho_bits.count_ones() as i32;
+                        }
+
                         for (cx, cy, tile) in game.board.tiles.iter() {
                             if crate::simd::both_zero(tile.occ_white, tile.occ_black) {
                                 continue;
@@ -1010,22 +1028,6 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         } else {
                                             black_bishop_colors.1 = true;
                                         }
-                                    }
-                                }
-
-                                // 6. Slider counts
-                                if (tile.occ_diag_sliders & (1 << idx)) != 0 {
-                                    if is_white {
-                                        w_diag_count += 1;
-                                    } else {
-                                        b_diag_count += 1;
-                                    }
-                                }
-                                if (tile.occ_ortho_sliders & (1 << idx)) != 0 {
-                                    if is_white {
-                                        w_ortho_count += 1;
-                                    } else {
-                                        b_ortho_count += 1;
                                     }
                                 }
 

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -581,12 +581,11 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                         white_rq.clear();
                         black_rq.clear();
 
-                        // Slider counts
-                        for (_cx, _cy, tile) in game.board.tiles.iter() {
+                        for (cx, cy, tile) in game.board.tiles.iter() {
                             if crate::simd::both_zero(tile.occ_white, tile.occ_black) {
                                 continue;
                             }
-
+                            
                             // Count diagonals and orthogonals directly from bitboards
                             let w_diag_bits = tile.occ_diag_sliders & tile.occ_white;
                             let b_diag_bits = tile.occ_diag_sliders & tile.occ_black;
@@ -597,12 +596,6 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                             b_diag_count += b_diag_bits.count_ones() as i32;
                             w_ortho_count += w_ortho_bits.count_ones() as i32;
                             b_ortho_count += b_ortho_bits.count_ones() as i32;
-                        }
-
-                        for (cx, cy, tile) in game.board.tiles.iter() {
-                            if crate::simd::both_zero(tile.occ_white, tile.occ_black) {
-                                continue;
-                            }
 
                             let mut bits = tile.occ_all;
                             while bits != 0 {

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -702,7 +702,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         // Tropism sums across all royals
                                         if piece_val > 0 {
                                             let d = dx.max(dy);
-                                            w_attacking_tropism += piece_val / (d as i32 + 10);
+                                            w_attacking_tropism += piece_val / (d as i32 + 5);
                                         }
                                     }
                                     // Single pass through WHITE royals for friendly tropism
@@ -710,7 +710,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         for &wk in white_royals {
                                             let d = (x - wk.x).abs().max((y - wk.y).abs());
                                             w_defensive_tropism +=
-                                                piece_val.min(350) / (d as i32 + 10);
+                                                piece_val.min(350) / (d as i32 + 5);
                                         }
                                     }
                                 } else {
@@ -728,7 +728,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         // Tropism sums across all royals
                                         if piece_val > 0 {
                                             let d = dx.max(dy);
-                                            b_attacking_tropism += piece_val / (d as i32 + 10);
+                                            b_attacking_tropism += piece_val / (d as i32 + 5);
                                         }
                                     }
                                     // Single pass through BLACK royals for friendly tropism
@@ -736,7 +736,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         for &bk in black_royals {
                                             let d = (x - bk.x).abs().max((y - bk.y).abs());
                                             b_defensive_tropism +=
-                                                piece_val.min(350) / (d as i32 + 10);
+                                                piece_val.min(350) / (d as i32 + 5);
                                         }
                                     }
                                 }


### PR DESCRIPTION
**This pull request improves the SPRT web by the following changes:**
- **New Feature:** Added a `Scattered Leapers` variant
- **Bug fix:** Testing SPRT on the web no longer halts immediately when the max games is unlimited.

> [!NOTE]
> I've also made changes in the engine, resulting in **~16 Elo improvement.**
```
LLR: 2.96 [-2.94, 2.94]
SPRT: PASS

Final Summary:
  TC: 10+0.1 | Concurrency: 12 | Variants: 15 | Adjudication: Disabled
  Elo: 15.6 +/- 6.3
  Record: 529W - 451L - 756D (1736 total)
  ALERT: 7 games ended by timeout (NEW ENGINE ONLY)

Per-Variant Breakdown:
  [Classical]: 22W - 17L - 77D, Elo: 15.0 +/- 18.7
  [Classical_Plus]: 29W - 29L - 60D, Elo: -0.0 +/- 22.4
  [CoaIP]: 29W - 15L - 72D, Elo: 42.1 +/- 19.8
  [CoaIP_HO]: 31W - 26L - 59D, Elo: 15.0 +/- 22.6
  [CoaIP_NO]: 37W - 31L - 48D, Elo: 18.0 +/- 24.7
  [CoaIP_RO]: 41W - 25L - 50D, Elo: 48.2 +/- 24.4
  [Confined_Classical]: 38W - 35L - 43D, Elo: 9.0 +/- 25.6
  [Core]: 25W - 40L - 49D, Elo: -46.0 +/- 24.6
  [Knightline]: 57W - 44L - 15D, Elo: 39.1 +/- 30.3
  [Palace]: 52W - 52L - 10D, Elo: -0.0 +/- 31.1
  [Pawndard]: 22W - 22L - 70D, Elo: -0.0 +/- 20.2
  [Scattered_Leapers]: 15W - 11L - 90D, Elo: 12.0 +/- 15.2
  [Space]: 51W - 28L - 35D, Elo: 71.1 +/- 27.4
  [Space_Classic]: 48W - 47L - 21D, Elo: 3.0 +/- 29.2
  [Standarch]: 32W - 29L - 57D, Elo: 8.8 +/- 23.0
```