### PR TITLE
Multiple king support in tropism calculation

### DIFF
--- a/sprt/web/index.html
+++ b/sprt/web/index.html
@@ -517,6 +517,9 @@
             <select id="sprtVariants" multiple style="height: 120px">
               <!-- Variants will be populated by JavaScript -->
             </select>
+            <button class="btn btn-secondary" id="resetToDefault">
+              Reset to Default
+            </button>
             <small style="
                   color: var(--text-dim);
                   margin-top: 0.25rem;

--- a/sprt/web/main.js
+++ b/sprt/web/main.js
@@ -3,7 +3,7 @@ const EngineOld = wasmOld.Engine;
 import initNew, * as wasmNew from './pkg-new/hydrochess_wasm.js';
 const EngineNew = wasmNew.Engine;
 const initThreadPoolNew = wasmNew.initThreadPool;
-import { getVariantData, getAllVariants, generateSetupICN, engineLetterToICNCode, getVariantsWithCustomEval } from './variants.js';
+import { getVariantData, getAllVariants, generateSetupICN, engineLetterToICNCode, getVariantsWithCustomEval, getVariantsWithDefaultDisabled } from './variants.js';
 
 let isNewEngineMT = false;
 
@@ -168,9 +168,8 @@ function populateVariantDropdown() {
     // Get variants with custom eval (these will be disabled by default for SPRT stability)
     const customEvalVariants = new Set(getVariantsWithCustomEval());
 
-    // Variants to disable by default: custom evals AND Abundance
-    const defaultsDisabled = new Set(customEvalVariants);
-    defaultsDisabled.add('Abundance');
+    // Variants to disable by default
+    const defaultsDisabled = customEvalVariants.union(new Set(getVariantsWithDefaultDisabled()));
 
     sprtVariantsEl.innerHTML = '';
     availableVariants.forEach(variant => {

--- a/sprt/web/main.js
+++ b/sprt/web/main.js
@@ -55,6 +55,7 @@ const sprtMaxMoves = document.getElementById('sprtMaxMoves');
 const sprtMaterialThresholdEl = document.getElementById('sprtMaterialAdjudication');
 const sprtSearchNoiseEl = document.getElementById('sprtSearchNoise');
 const sprtVariantsEl = document.getElementById('sprtVariants');
+const resetToDefaultBtn = document.getElementById('resetToDefault');
 const runSprtBtn = document.getElementById('runSprt');
 const stopSprtBtn = document.getElementById('stopSprt');
 const sprtWinsEl = document.getElementById('sprtWins');
@@ -1318,6 +1319,7 @@ function downloadGamesJson() {
     log('Downloaded ' + games.length + ' games as JSON', 'success');
 }
 
+resetToDefaultBtn.addEventListener('click', populateVariantDropdown);
 runSprtBtn.addEventListener('click', runSprt);
 stopSprtBtn.addEventListener('click', stopSprt);
 copyLogBtn.addEventListener('click', copyLog);

--- a/sprt/web/variants.js
+++ b/sprt/web/variants.js
@@ -90,6 +90,7 @@ const VARIANTS = {
             promotion_ranks: { white: ['6'], black: ['-6'] },
             promotions_allowed: ['q', 'r', 'b', 'n', 'g', 'h', 'c'],
         },
+        defaultDisabled: true,
     },
     Pawn_Horde: {
         position: 'k5,2+|q4,2|r1,2+|n7,2|n2,2|r8,2+|b3,2|b6,2|P2,-1+|P3,-1+|P6,-1+|P7,-1+|P1,-2+|P2,-2+|P4,-2+|P5,-2+|P6,-2+|P7,-2+|P8,-2+|P1,-3+|P2,-3+|P4,-3+|P5,-3+|P6,-3+|P7,-3+|P8,-3+|P1,-4+|P2,-4+|P4,-4+|P5,-4+|P6,-4+|P7,-4+|P8,-4+|P1,-5+|P2,-5+|P4,-5+|P5,-5+|P6,-5+|P7,-5+|P8,-5+|P1,-6+|P2,-6+|P4,-6+|P5,-6+|P6,-6+|P7,-6+|P8,-6+|P3,-2+|P3,-3+|P3,-4+|P3,-5+|P3,-6+|P1,-7+|P2,-7+|P3,-7+|P4,-7+|P5,-7+|P6,-7+|P7,-7+|P8,-7+|P0,-6+|P0,-7+|P9,-6+|P9,-7+|p9,2+|p1,1+|p2,1+|p3,1+|p4,1+|p5,1+|p6,1+|p7,1+|p8,1+|p0,2+',
@@ -129,6 +130,33 @@ const VARIANTS = {
             promotions_allowed: ['q', 'r', 'b', 'n'],
         },
     },
+    // Custom variant that uses all fairy leapers
+    Double_King_Classical: {
+        position: 'k5,8+|k4,8+|n2,8|n7,8|r1,8+|r8,8+|b3,8|b6,8|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|p8,7+|K5,1+|K4,1+|N2,1|N7,1|R1,1+|R8,1+|B3,1|B6,1|P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P6,2+|P7,2+|P8,2+',
+        game_rules: {
+            promotions_allowed: ['q', 'r', 'b', 'n'],
+            win_conditions: { white: ['allroyalscaptured'], black: ['allroyalscaptured'] },
+        },
+        defaultDisabled: true,
+    },
+    Double_King_Chess: {
+        position: "k5,8+|k4,8+|n2,8|n7,8|r1,8+|r8,8+|b3,8|b6,8|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|p8,7+|K5,1+|K4,1+|N2,1|N7,1|R1,1+|R8,1+|B3,1|B6,1|P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P6,2+|P7,2+|P8,2+",
+        game_rules: {
+            promotions_allowed: ['q', 'r', 'b', 'n'],
+        },
+        worldBorder: 0,
+        defaultDisabled: true,
+    },
+    Triple_King_Maze: {
+        position: "vo0,0|vo1,0|vo2,0|vo3,0|vo4,0|vo5,0|vo10,0|vo0,9|vo10,1|vo10,2|vo10,9|vo9,9|vo6,9|vo8,9|vo7,9|vo0,8|vo0,7|vo0,4|vo0,3|vo10,6|vo10,5|vo3,9|vo3,6|vo3,5|vo3,4|vo3,3|vo7,5|vo7,4|vo7,3|vo4,9|vo5,9|vo6,0|vo7,0|vo-2,7|vo-1,7|vo11,2|vo12,2|vo-6,12|vo-6,11|vo-6,6|vo-6,5|vo-6,2|vo-6,-1|vo-6,-2|vo-6,-3|vo16,-3|vo16,-2|vo16,-1|vo16,2|vo16,4|vo16,7|vo16,10|vo16,11|vo16,12|vo-3,4|vo-3,3|vo-3,2|vo-3,1|vo-3,-3|vo-3,0|vo-3,7|vo-3,9|vo-3,8|vo13,2|vo13,1|vo13,0|vo13,5|vo13,6|vo13,7|vo13,8|vo13,9|vo0,-3|vo1,-3|vo2,-3|vo5,-3|vo8,12|vo9,12|vo10,12|vo-3,12|vo0,12|vo10,-3|vo13,-3|vo13,12|vo0,14|vo0,13|vo10,-4|vo10,-5|vo15,7|vo-5,2|vo-4,2|vo-3,-4|vo-3,-5|vo13,14|vo13,13|vo-6,10|vo16,3|vo-6,7|vo6,-3|vo7,-3|vo3,12|vo4,12|vo5,12|vo-8,-6|vo-7,-6|vo-6,-6|vo-3,-6|vo13,15|vo16,15|vo17,15|vo18,15|vo-2,-6|vo-1,-6|vo0,-6|vo1,-6|vo2,-6|vo3,-6|vo7,-6|vo8,-6|vo9,-6|vo10,-6|vo0,15|vo1,15|vo2,15|vo3,15|vo7,15|vo8,15|vo9,15|vo10,15|vo11,15|vo12,15|vo11,-6|vo12,-6|vo13,-6|vo16,-6|vo17,-6|vo18,-6|vo-3,15|vo-2,15|vo-1,15|vo-8,15|vo-7,15|vo-6,15|vo7,6|vo14,7|k5,7|k-8,17|k18,17|q5,17|n14,14|n-4,14|n14,8|n0,11|n0,10|n10,11|n10,10|r-8,14|r-7,13|r-2,8|r-1,8|r17,13|r18,14|r5,16|b5,6|b4,13|b6,13|b-7,17|b-7,16|b17,17|b17,16|b7,7|b3,7|p4,8+|p5,8+|p6,8+|p15,6+|p-5,8+|p1,9+|p2,9+|p8,8+|p9,8+|p-8,8+|p-7,8+|p17,4+|p18,4+|K5,2|K-8,-8|K18,-8|Q5,-8|N14,-5|N-4,-5|N-4,1|N10,-1|N10,-2|N0,-1|N0,-2|R17,-4|R11,1|R12,1|R18,-5|R-8,-5|R-7,-4|R5,-7|B5,3|B4,-4|B6,-4|B5,-2|B-7,-7|B-7,-8|B17,-7|B17,-8|B7,2|B3,2|P4,1+|P5,1+|P6,1+|P15,1+|P-5,3+|P8,0+|P9,0+|P1,1+|P2,1+|P17,1+|P18,1+|P-8,5+|P-7,5+|b5,11",
+        game_rules: {
+            promotions_allowed: ['q', 'r', 'b', 'n'],
+            win_conditions: { white: ['checkmate'], black: ['allroyalscaptured'] },
+            move_rule: 200,
+        },
+        worldBorder: 0,
+        defaultDisabled: true,
+    }
 };
 
 // Get variant position and special rights
@@ -170,6 +198,11 @@ function getAllVariants() {
 // Get variants that have custom evaluation (volatility warning for SPRT)
 function getVariantsWithCustomEval() {
     return Object.keys(VARIANTS).filter(name => VARIANTS[name].hasCustomEval === true);
+}
+
+// Get variants that are not default (volatility warning for SPRT)
+function getVariantsWithDefaultDisabled() {
+    return Object.keys(VARIANTS).filter(name => VARIANTS[name].defaultDisabled === true);
 }
 
 // Map internal engine piece letters to infinitechess.org ICN codes (lowercase for ICN)
@@ -251,4 +284,4 @@ function generateSetupICN(variantName, startTurn, halfmoveClock, fullmoveNumber,
     return `${variantTag}${startTurn} ${halfmoveClock}/${moveLimit} ${fullmoveNumber} ${promoToken} ${boundsToken} ${startPosStr}${movesStr ? ' ' + movesStr : ''}`;
 }
 
-export { VARIANTS, getVariantData, getAllVariants, getVariantsWithCustomEval, engineLetterToICNCode, generateSetupICN };
+export { VARIANTS, getVariantData, getAllVariants, getVariantsWithCustomEval, getVariantsWithDefaultDisabled, engineLetterToICNCode, generateSetupICN };

--- a/sprt/web/variants.js
+++ b/sprt/web/variants.js
@@ -271,17 +271,25 @@ function generateSetupICN(variantName, startTurn, halfmoveClock, fullmoveNumber,
     // 3. Move Rule Limit (50-move rule)
     const moveLimit = vdata.game_rules.move_rule || 100;
 
-    // 4. Moves string: "from1,y1>to1,y1|from2,y2>to2,y2"
+    // 4. Win conditions
+    let winConditionStr = vdata.game_rules.win_conditions.white[0] + ',' + vdata.game_rules.win_conditions.black[0];
+    if (winConditionStr == 'checkmate,checkmate') {
+        winConditionStr = '';
+    } else {
+        winConditionStr += ' ';
+    }
+
+    // 5. Moves string: "from1,y1>to1,y1|from2,y2>to2,y2"
     const movesStr = moveHistoryList.map(h => {
         let m = `${h.from}>${h.to}`;
         if (h.promotion) m += `=${h.promotion}`;
         return m;
     }).join('|');
 
-    // 5. Include variant tag so engine recognizes the variant
+    // 6. Include variant tag so engine recognizes the variant
     const variantTag = `[Variant "${variantName}"] `;
 
-    return `${variantTag}${startTurn} ${halfmoveClock}/${moveLimit} ${fullmoveNumber} ${promoToken} ${boundsToken} ${startPosStr}${movesStr ? ' ' + movesStr : ''}`;
+    return `${variantTag}${startTurn} ${halfmoveClock}/${moveLimit} ${fullmoveNumber} ${promoToken} ${boundsToken} ${winConditionStr}${startPosStr}${movesStr ? ' ' + movesStr : ''}`;
 }
 
 export { VARIANTS, getVariantData, getAllVariants, getVariantsWithCustomEval, getVariantsWithDefaultDisabled, engineLetterToICNCode, generateSetupICN };

--- a/src/bin/sprt.rs
+++ b/src/bin/sprt.rs
@@ -1387,6 +1387,9 @@ fn main() {
                     Variant::Obstocean,
                     Variant::Chess,
                     Variant::ScatteredLeapers,
+                    Variant::DoubleKingClassical,
+                    Variant::DoubleKingChess,
+                    Variant::TripleKingMaze,
                 ]
             } else {
                 let mut parsed = Vec::new();
@@ -1413,6 +1416,9 @@ fn main() {
                             | "obstocean"
                             | "chess"
                             | "scattered_leapers"
+                            | "double_king_classical"
+                            | "double_king_chess"
+                            | "triple_king_maze"
                     );
                     if !known {
                         eprintln!("Error: Unknown variant '{}'", name);

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -486,21 +486,13 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
         (None, None) => (0, 0),
     };
 
-    // Slider counts for attack bonus (white, black)
+    // Slider counts for attack bonus (white, black) and attacking units
     let mut w_diag_count = 0;
     let mut w_ortho_count = 0;
     let mut b_diag_count = 0;
     let mut b_ortho_count = 0;
-
-    // Attacking/Defending units
     let mut w_additional_attack_units = 0;
     let mut b_additional_attack_units = 0;
-    let mut w_defender_units_in_distance: [i32; 8] = [0; 8];
-    let mut b_defender_units_in_distance: [i32; 8] = [0; 8];
-    let mut w_defender_units = 0;
-    let mut b_defender_units = 0;
-    let mut w_defender_bonus = 0;
-    let mut b_defender_bonus = 0;
 
     // Threat points for defense urgency
     let mut w_threat_points = 0;
@@ -532,10 +524,28 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
     let mut w_king_ring_covered = false;
     let mut b_king_ring_covered = false;
 
+    // Attacking and Defensive Tropism
     let mut w_attacking_tropism: i32 = 0;
     let mut w_defensive_tropism: i32 = 0;
     let mut b_attacking_tropism: i32 = 0;
     let mut b_defensive_tropism: i32 = 0;
+
+    let mut white_royal_tropisms: SmallVec<[_; 1]> = game.white_royals.iter().map(|r| RoyalTropismMetrics {
+        tropism_addend: 0, // placeholder
+        attacking_units: 0, // placeholder
+        defender_units: 0, // placeholder
+        defender_units_in_distance: [0; 8],
+        x: r.x,
+        y: r.y,
+    }).collect();
+    let mut black_royal_tropisms: SmallVec<[_; 1]> = game.black_royals.iter().map(|r| RoyalTropismMetrics {
+        tropism_addend: 0, // placeholder
+        attacking_units: 0, // placeholder
+        defender_units: 0, // placeholder
+        defender_units_in_distance: [0; 8],
+        x: r.x,
+        y: r.y,
+    }).collect();
 
     // Interaction threat constants
     const PAWN_THREATENS_MINOR: i32 = 25;
@@ -640,15 +650,15 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                 }
 
                                 // 2.2. Special leapers can be attackers if they are <=20 squares away from the enemy king
-                                let (your_king_pos, enemy_king_pos, piece_pos) = if is_white {
-                                    (white_king, black_king, (x, y))
+                                let (your_royals, enemy_royals) = if is_white {
+                                    (&mut white_royal_tropisms, &mut black_royal_tropisms)
                                 } else {
-                                    (black_king, white_king, (x, y))
+                                    (&mut black_royal_tropisms, &mut white_royal_tropisms)
                                 };
                                 
-                                if let Some(ek) = enemy_king_pos {
-                                    let dx = (piece_pos.0 - ek.x).abs();
-                                    let dy = (piece_pos.1 - ek.y).abs();
+                                for ek in enemy_royals {
+                                    let dx = (x - ek.x).abs();
+                                    let dy = (y - ek.y).abs();
 
                                     if dx <= 20 && dy <= 20 {
                                         let leaper_attack_units = if matches!(pt, PieceType::Rose) {
@@ -667,36 +677,32 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                             0
                                         };
 
-                                        if is_white {
-                                            w_additional_attack_units += leaper_attack_units;
-                                        } else {
-                                            b_additional_attack_units += leaper_attack_units;
-                                        }
+                                        ek.attacking_units += leaper_attack_units;
                                     }
                                 }
 
                                 // 2.3. Also account for defenders when calculating attack potential
                                 if piece.color() == PlayerColor::Neutral {
                                     // Neutral pieces can be considered weak defenders if they are close to the king
-                                    if let Some(king) = white_king {
-                                        let d = (piece_pos.0 - king.x).abs().max((piece_pos.1 - king.y).abs());
+                                    for king in &mut white_royal_tropisms {
+                                        let d = (x - king.x).abs().max((y - king.y).abs());
                                         if d <= 7 {
                                             let defender_units = 25 / d as i32;
-                                            w_defender_units_in_distance[d as usize] += defender_units;
+                                            king.defender_units_in_distance[d as usize] += defender_units;
                                         }
                                     }
-                                    if let Some(king) = black_king {
-                                        let d = (piece_pos.0 - king.x).abs().max((piece_pos.1 - king.y).abs());
+                                    for king in &mut black_royal_tropisms {
+                                        let d = (x - king.x).abs().max((y - king.y).abs());
                                         if d <= 7 {
                                             let defender_units = 25 / d as i32;
-                                            b_defender_units_in_distance[d as usize] += defender_units;
+                                            king.defender_units_in_distance[d as usize] += defender_units;
                                         }
                                     }
                                     continue;
                                 }
 
-                                if let Some(yk) = your_king_pos {
-                                    let d = (piece_pos.0 - yk.x).abs().max((piece_pos.1 - yk.y).abs());
+                                for yk in your_royals {
+                                    let d = (x - yk.x).abs().max((y - yk.y).abs());
 
                                     if d <= 7 {
                                         // Defensive units are higher if it is a piece and very close to the king
@@ -708,11 +714,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                             0
                                         } as i32;
 
-                                        if is_white {
-                                            w_defender_units_in_distance[d as usize] += defender_units;
-                                        } else {
-                                            b_defender_units_in_distance[d as usize] += defender_units;
-                                        }
+                                        yk.defender_units_in_distance[d as usize] += defender_units;
                                     }
                                 }
                             }
@@ -721,27 +723,43 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                         // 3. Calculate total sliders and defender units
                         let w_total_sliders = w_diag_count + w_ortho_count;
                         let b_total_sliders = b_diag_count + b_ortho_count;
-                        for d in 1..8 {
-                            let w_defender_units_to_add = w_defender_units_in_distance[d as usize];
-                            let b_defender_units_to_add = b_defender_units_in_distance[d as usize];
-                            w_defender_units += w_defender_units_to_add;
-                            b_defender_units += b_defender_units_to_add;
 
-                            // Apply defender bonus if there are a lot of defenders at a distance
-                            if w_defender_units_to_add >= 200 {
-                                w_defender_bonus = (300 + 100 * d - 100 * b_total_sliders).max(0);
+                        for king in &mut white_royal_tropisms {
+                            let mut defender_bonus = 0;
+                            for d in 1..8 {
+                                let defender_units_to_add = king.defender_units_in_distance[d as usize];
+                                king.defender_units += defender_units_to_add;
+
+                                // Apply defender bonus if there are a lot of defenders at a distance
+                                if defender_units_to_add >= 200 {
+                                    defender_bonus = (300 + 100 * d - 100 * b_total_sliders).max(0);
+                                }
                             }
-                            if b_defender_units_to_add >= 200 {
-                                b_defender_bonus = (300 + 100 * d - 100 * w_total_sliders).max(0);
-                            }
+                            king.defender_units += defender_bonus;
                         }
-                        w_defender_units += w_defender_bonus;
-                        b_defender_units += b_defender_bonus;
 
-                        let w_total_effective_units = (w_total_sliders + (w_additional_attack_units - b_defender_units) / 100).max(0) as usize;
-                        let b_total_effective_units = (b_total_sliders + (b_additional_attack_units - w_defender_units) / 100).max(0) as usize;
-                        let w_tropism_addend = compute_tropism_addend(w_total_effective_units);
-                        let b_tropism_addend = compute_tropism_addend(b_total_effective_units);
+                        for king in &mut black_royal_tropisms {
+                            let mut defender_bonus = 0;
+                            for d in 1..8 {
+                                let defender_units_to_add = king.defender_units_in_distance[d as usize];
+                                king.defender_units += defender_units_to_add;
+
+                                // Apply defender bonus if there are a lot of defenders at a distance
+                                if defender_units_to_add >= 200 {
+                                    defender_bonus = (300 + 100 * d - 100 * w_total_sliders).max(0);
+                                }
+                            }
+                            king.defender_units += defender_bonus;
+                        }
+
+                        for king in &mut white_royal_tropisms {
+                            let total_effective_units = w_total_sliders + (w_additional_attack_units + king.attacking_units - king.defender_units) / 100;
+                            king.tropism_addend = compute_tropism_addend(total_effective_units);
+                        }
+                        for king in &mut black_royal_tropisms {
+                            let total_effective_units = b_total_sliders + (b_additional_attack_units + king.attacking_units - king.defender_units) / 100;
+                            king.tropism_addend = compute_tropism_addend(total_effective_units);
+                        }
 
                         // Main piece loop
                         for (cx, cy, tile) in game.board.tiles.iter() {
@@ -854,7 +872,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                 if is_white {
                                     // Unified pass through BLACK royals: slider zone, enemy tropism
                                     let mut slider_counted = false;
-                                    for &bk in black_royals {
+                                    for bk in &black_royal_tropisms {
                                         let dx = (x - bk.x).abs();
                                         let dy = (y - bk.y).abs();
 
@@ -866,21 +884,21 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         // Tropism sums across all royals
                                         if piece_val > 0 {
                                             let d = dx.max(dy);
-                                            w_attacking_tropism += piece_val / (d as i32 + w_tropism_addend);
+                                            w_attacking_tropism += piece_val / (d as i32 + bk.tropism_addend);
                                         }
                                     }
                                     // Single pass through WHITE royals for friendly tropism
                                     if piece_val > 0 {
-                                        for &wk in white_royals {
+                                        for wk in &white_royal_tropisms {
                                             let d = (x - wk.x).abs().max((y - wk.y).abs());
                                             w_defensive_tropism +=
-                                                piece_val.min(350) / (d as i32 + b_tropism_addend);
+                                                piece_val.min(350) / (d as i32 + wk.tropism_addend);
                                         }
                                     }
                                 } else {
                                     // Unified pass through WHITE royals: slider zone, enemy tropism
                                     let mut slider_counted = false;
-                                    for &wk in white_royals {
+                                    for wk in &white_royal_tropisms {
                                         let dx = (x - wk.x).abs();
                                         let dy = (y - wk.y).abs();
 
@@ -892,15 +910,15 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         // Tropism sums across all royals
                                         if piece_val > 0 {
                                             let d = dx.max(dy);
-                                            b_attacking_tropism += piece_val / (d as i32 + b_tropism_addend);
+                                            b_attacking_tropism += piece_val / (d as i32 + wk.tropism_addend);
                                         }
                                     }
                                     // Single pass through BLACK royals for friendly tropism
                                     if piece_val > 0 {
-                                        for &bk in black_royals {
+                                        for bk in &black_royal_tropisms {
                                             let d = (x - bk.x).abs().max((y - bk.y).abs());
                                             b_defensive_tropism +=
-                                                piece_val.min(350) / (d as i32 + w_tropism_addend);
+                                                piece_val.min(350) / (d as i32 + bk.tropism_addend);
                                         }
                                     }
                                 }
@@ -1795,11 +1813,19 @@ fn evaluate_pieces_processed<T: EvaluationTracer>(
     (w_activity + w_pair_bonus) - (b_activity + b_pair_bonus)
 }
 
-const TROPISM_SLIDER_WEIGHTS: [i32; 8] = [11, 11, 10, 9, 8, 7, 6, 5];
+struct RoyalTropismMetrics {
+    tropism_addend: i32,
+    attacking_units: i32,
+    defender_units: i32,
+    defender_units_in_distance: [i32; 8],
+    x: i64,
+    y: i64,
+}
+
 /// Calculates the right distance to attack the other side and defend your own king.
 #[inline(always)]
-fn compute_tropism_addend(slider_count: usize) -> i32 {
-    TROPISM_SLIDER_WEIGHTS[slider_count.min(7)]
+fn compute_tropism_addend(slider_count: i32) -> i32 {
+    12 - slider_count.clamp(1, 7)
 }
 
 fn compute_attack_readiness_optimized(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,10 @@ pub enum Variant {
     Chess,
     // Custom variant that uses all fairy leapers
     ScatteredLeapers,
+    // Custom variants that uses more than 1 king
+    DoubleKingClassical,
+    DoubleKingChess,
+    TripleKingMaze, // variant created by Nikita
 }
 
 impl Variant {
@@ -107,6 +111,15 @@ impl Variant {
             Variant::ScatteredLeapers => {
                 "w 0/100 1 (8|1) P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P7,2+|P8,2+|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|R1,1+|r1,8+|r8,8+|B3,1|B6,1|b3,8|b6,8|GU2,1|gu2,8|K5,1+|k5,8+|gu7,8|P11,1+|P-2,1+|P-5,0+|P14,0+|p-2,8+|p-5,9+|p11,8+|p14,9+|nr4,9|NR4,0|CA9,-2|ca9,11|ca0,11|ze-3,12|ze12,12|ZE12,-3|GI-5,-6|GI14,-6|gi14,15|gi-5,15|ha-1,14|ha10,14|P6,2+|RO7,-6|p8,7+|ZE-3,-3|CA0,-2|GU7,1|R8,1+|HA10,-5|HA-1,-5|ro7,15"
             }
+            Variant::DoubleKingClassical => {
+                "w 0/100 1 (8|1) allroyalscaptured,allroyalscaptured k5,8+|k4,8+|n2,8|n7,8|r1,8+|r8,8+|b3,8|b6,8|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|p8,7+|K5,1+|K4,1+|N2,1|N7,1|R1,1+|R8,1+|B3,1|B6,1|P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P6,2+|P7,2+|P8,2+"
+            }
+            Variant::DoubleKingChess => {
+                "w 0/100 1 (8|1) 1,8,1,8 k5,8+|k4,8+|n2,8|n7,8|r1,8+|r8,8+|b3,8|b6,8|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|p8,7+|K5,1+|K4,1+|N2,1|N7,1|R1,1+|R8,1+|B3,1|B6,1|P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P6,2+|P7,2+|P8,2+"
+            }
+            Variant::TripleKingMaze => {
+                "w 0/200 1 (8|1) -8,18,-8,17 checkmate,allroyalscaptured vo0,0|vo1,0|vo2,0|vo3,0|vo4,0|vo5,0|vo10,0|vo0,9|vo10,1|vo10,2|vo10,9|vo9,9|vo6,9|vo8,9|vo7,9|vo0,8|vo0,7|vo0,4|vo0,3|vo10,6|vo10,5|vo3,9|vo3,6|vo3,5|vo3,4|vo3,3|vo7,5|vo7,4|vo7,3|vo4,9|vo5,9|vo6,0|vo7,0|vo-2,7|vo-1,7|vo11,2|vo12,2|vo-6,12|vo-6,11|vo-6,6|vo-6,5|vo-6,2|vo-6,-1|vo-6,-2|vo-6,-3|vo16,-3|vo16,-2|vo16,-1|vo16,2|vo16,4|vo16,7|vo16,10|vo16,11|vo16,12|vo-3,4|vo-3,3|vo-3,2|vo-3,1|vo-3,-3|vo-3,0|vo-3,7|vo-3,9|vo-3,8|vo13,2|vo13,1|vo13,0|vo13,5|vo13,6|vo13,7|vo13,8|vo13,9|vo0,-3|vo1,-3|vo2,-3|vo5,-3|vo8,12|vo9,12|vo10,12|vo-3,12|vo0,12|vo10,-3|vo13,-3|vo13,12|vo0,14|vo0,13|vo10,-4|vo10,-5|vo15,7|vo-5,2|vo-4,2|vo-3,-4|vo-3,-5|vo13,14|vo13,13|vo-6,10|vo16,3|vo-6,7|vo6,-3|vo7,-3|vo3,12|vo4,12|vo5,12|vo-8,-6|vo-7,-6|vo-6,-6|vo-3,-6|vo13,15|vo16,15|vo17,15|vo18,15|vo-2,-6|vo-1,-6|vo0,-6|vo1,-6|vo2,-6|vo3,-6|vo7,-6|vo8,-6|vo9,-6|vo10,-6|vo0,15|vo1,15|vo2,15|vo3,15|vo7,15|vo8,15|vo9,15|vo10,15|vo11,15|vo12,15|vo11,-6|vo12,-6|vo13,-6|vo16,-6|vo17,-6|vo18,-6|vo-3,15|vo-2,15|vo-1,15|vo-8,15|vo-7,15|vo-6,15|vo7,6|vo14,7|k5,7|k-8,17|k18,17|q5,17|n14,14|n-4,14|n14,8|n0,11|n0,10|n10,11|n10,10|r-8,14|r-7,13|r-2,8|r-1,8|r17,13|r18,14|r5,16|b5,6|b4,13|b6,13|b-7,17|b-7,16|b17,17|b17,16|b7,7|b3,7|p4,8+|p5,8+|p6,8+|p15,6+|p-5,8+|p1,9+|p2,9+|p8,8+|p9,8+|p-8,8+|p-7,8+|p17,4+|p18,4+|K5,2|K-8,-8|K18,-8|Q5,-8|N14,-5|N-4,-5|N-4,1|N10,-1|N10,-2|N0,-1|N0,-2|R17,-4|R11,1|R12,1|R18,-5|R-8,-5|R-7,-4|R5,-7|B5,3|B4,-4|B6,-4|B5,-2|B-7,-7|B-7,-8|B17,-7|B17,-8|B7,2|B3,2|P4,1+|P5,1+|P6,1+|P15,1+|P-5,3+|P8,0+|P9,0+|P1,1+|P2,1+|P17,1+|P18,1+|P-8,5+|P-7,5+|b5,11"
+            }
         }
     }
 
@@ -131,6 +144,9 @@ impl Variant {
             Variant::Obstocean => "Obstocean",
             Variant::Chess => "Chess",
             Variant::ScatteredLeapers => "Scattered_Leapers",
+            Variant::DoubleKingClassical => "Double_King_Classical",
+            Variant::DoubleKingChess => "Double_King_Chess",
+            Variant::TripleKingMaze => "Triple_King_Maze",
         }
     }
 
@@ -156,6 +172,9 @@ impl Variant {
             "obstocean" => Variant::Obstocean,
             "chess" => Variant::Chess,
             "scattered_leapers" => Variant::ScatteredLeapers,
+            "double_king_classical" => Variant::DoubleKingClassical,
+            "double_king_chess" => Variant::DoubleKingChess,
+            "triple_king_maze" => Variant::TripleKingMaze,
             _ => Variant::Classical, // Default fallback
         }
     }
@@ -824,6 +843,9 @@ mod tests {
             Variant::Obstocean,
             Variant::Chess,
             Variant::ScatteredLeapers,
+            Variant::DoubleKingClassical,
+            Variant::DoubleKingChess,
+            Variant::TripleKingMaze,
         ]
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,10 @@ pub enum Variant {
     Chess,
     // Custom variant that uses all fairy leapers
     ScatteredLeapers,
+    // Custom variants that uses more than 1 king
+    DoubleKingClassical,
+    DoubleKingChess,
+    TripleKingMaze, // variant created by Nikita
 }
 
 impl Variant {
@@ -107,6 +111,15 @@ impl Variant {
             Variant::ScatteredLeapers => {
                 "w 0/100 1 (8|1) P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P7,2+|P8,2+|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|R1,1+|r1,8+|r8,8+|B3,1|B6,1|b3,8|b6,8|GU2,1|gu2,8|K5,1+|k5,8+|gu7,8|P11,1+|P-2,1+|P-5,0+|P14,0+|p-2,8+|p-5,9+|p11,8+|p14,9+|nr4,9|NR4,0|CA9,-2|ca9,11|ca0,11|ze-3,12|ze12,12|ZE12,-3|GI-5,-6|GI14,-6|gi14,15|gi-5,15|ha-1,14|ha10,14|P6,2+|RO7,-6|p8,7+|ZE-3,-3|CA0,-2|GU7,1|R8,1+|HA10,-5|HA-1,-5|ro7,15"
             }
+            Variant::DoubleKingClassical => {
+                "w 0/100 1 (8|1) allroyalscaptured,allroyalscaptured k5,8+|k4,8+|n2,8|n7,8|r1,8+|r8,8+|b3,8|b6,8|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|p8,7+|K5,1+|K4,1+|N2,1|N7,1|R1,1+|R8,1+|B3,1|B6,1|P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P6,2+|P7,2+|P8,2+"
+            }
+            Variant::DoubleKingChess => {
+                "w 0/100 1 (8|1) 1,8,1,8 k5,8+|k4,8+|n2,8|n7,8|r1,8+|r8,8+|b3,8|b6,8|p1,7+|p2,7+|p3,7+|p4,7+|p5,7+|p6,7+|p7,7+|p8,7+|K5,1+|K4,1+|N2,1|N7,1|R1,1+|R8,1+|B3,1|B6,1|P1,2+|P2,2+|P3,2+|P4,2+|P5,2+|P6,2+|P7,2+|P8,2+"
+            }
+            Variant::TripleKingMaze => {
+                "w 0/200 1 (8|1) -8,18,-8,17 checkmate,allroyalscaptured vo0,0|vo1,0|vo2,0|vo3,0|vo4,0|vo5,0|vo10,0|vo0,9|vo10,1|vo10,2|vo10,9|vo9,9|vo6,9|vo8,9|vo7,9|vo0,8|vo0,7|vo0,4|vo0,3|vo10,6|vo10,5|vo3,9|vo3,6|vo3,5|vo3,4|vo3,3|vo7,5|vo7,4|vo7,3|vo4,9|vo5,9|vo6,0|vo7,0|vo-2,7|vo-1,7|vo11,2|vo12,2|vo-6,12|vo-6,11|vo-6,6|vo-6,5|vo-6,2|vo-6,-1|vo-6,-2|vo-6,-3|vo16,-3|vo16,-2|vo16,-1|vo16,2|vo16,4|vo16,7|vo16,10|vo16,11|vo16,12|vo-3,4|vo-3,3|vo-3,2|vo-3,1|vo-3,-3|vo-3,0|vo-3,7|vo-3,9|vo-3,8|vo13,2|vo13,1|vo13,0|vo13,5|vo13,6|vo13,7|vo13,8|vo13,9|vo0,-3|vo1,-3|vo2,-3|vo5,-3|vo8,12|vo9,12|vo10,12|vo-3,12|vo0,12|vo10,-3|vo13,-3|vo13,12|vo0,14|vo0,13|vo10,-4|vo10,-5|vo15,7|vo-5,2|vo-4,2|vo-3,-4|vo-3,-5|vo13,14|vo13,13|vo-6,10|vo16,3|vo-6,7|vo6,-3|vo7,-3|vo3,12|vo4,12|vo5,12|vo-8,-6|vo-7,-6|vo-6,-6|vo-3,-6|vo13,15|vo16,15|vo17,15|vo18,15|vo-2,-6|vo-1,-6|vo0,-6|vo1,-6|vo2,-6|vo3,-6|vo7,-6|vo8,-6|vo9,-6|vo10,-6|vo0,15|vo1,15|vo2,15|vo3,15|vo7,15|vo8,15|vo9,15|vo10,15|vo11,15|vo12,15|vo11,-6|vo12,-6|vo13,-6|vo16,-6|vo17,-6|vo18,-6|vo-3,15|vo-2,15|vo-1,15|vo-8,15|vo-7,15|vo-6,15|vo7,6|vo14,7|k5,7|k-8,17|k18,17|q5,17|n14,14|n-4,14|n14,8|n0,11|n0,10|n10,11|n10,10|r-8,14|r-7,13|r-2,8|r-1,8|r17,13|r18,14|r5,16|b5,6|b4,13|b6,13|b-7,17|b-7,16|b17,17|b17,16|b7,7|b3,7|p4,8+|p5,8+|p6,8+|p15,6+|p-5,8+|p1,9+|p2,9+|p8,8+|p9,8+|p-8,8+|p-7,8+|p17,4+|p18,4+|K5,2|K-8,-8|K18,-8|Q5,-8|N14,-5|N-4,-5|N-4,1|N10,-1|N10,-2|N0,-1|N0,-2|R17,-4|R11,1|R12,1|R18,-5|R-8,-5|R-7,-4|R5,-7|B5,3|B4,-4|B6,-4|B5,-2|B-7,-7|B-7,-8|B17,-7|B17,-8|B7,2|B3,2|P4,1+|P5,1+|P6,1+|P15,1+|P-5,3+|P8,0+|P9,0+|P1,1+|P2,1+|P17,1+|P18,1+|P-8,5+|P-7,5+|b5,11"
+            }
         }
     }
 
@@ -131,6 +144,9 @@ impl Variant {
             Variant::Obstocean => "Obstocean",
             Variant::Chess => "Chess",
             Variant::ScatteredLeapers => "Scattered_Leapers",
+            Variant::DoubleKingClassical => "Double_King_Classical",
+            Variant::DoubleKingChess => "Double_King_Chess",
+            Variant::TripleKingMaze => "Triple_King_Maze",
         }
     }
 
@@ -156,6 +172,9 @@ impl Variant {
             "obstocean" => Variant::Obstocean,
             "chess" => Variant::Chess,
             "scattered_leapers" => Variant::ScatteredLeapers,
+            "double_king_classical" => Variant::DoubleKingClassical,
+            "double_king_chess" => Variant::DoubleKingChess,
+            "triple_king_maze" => Variant::TripleKingMaze,
             _ => Variant::Classical, // Default fallback
         }
     }
@@ -164,6 +183,8 @@ impl Variant {
         match self {
             Variant::Chess => (1, 8, 1, 8),
             Variant::Obstocean => (-6, 15, -3, 12),
+            Variant::DoubleKingChess => (1, 8, 1, 8),
+            Variant::TripleKingMaze => (-8, 18, -8, 17),
             _ => (
                 -1_000_000_000_000_000,
                 1_000_000_000_000_000,
@@ -824,6 +845,9 @@ mod tests {
             Variant::Obstocean,
             Variant::Chess,
             Variant::ScatteredLeapers,
+            Variant::DoubleKingClassical,
+            Variant::DoubleKingChess,
+            Variant::TripleKingMaze,
         ]
     }
 
@@ -858,6 +882,8 @@ mod tests {
 
         assert_eq!(Variant::Chess.get_default_bounds(), (1, 8, 1, 8));
         assert_eq!(Variant::Obstocean.get_default_bounds(), (-6, 15, -3, 12));
+        assert_eq!(Variant::DoubleKingChess.get_default_bounds(), (1, 8, 1, 8));
+        assert_eq!(Variant::TripleKingMaze.get_default_bounds(), (-8, 18, -8, 17));
         assert_eq!(
             Variant::Space.get_default_bounds(),
             (


### PR DESCRIPTION
### Changes:
- The tropism addend calculation now takes multiple kings into account instead of the first king, resulting in an average of **+24 Elo** in variants with multiple kings.
- Add variants with multiple kings: “Double King Classical,” “Double King Chess,” and “Triple King Maze”
- Changes in SPRT web:
    - Add “Reset to Default” button.
    - Fix the incomplete setup ICN when win conditions are present.

### SPRT Results:
```
Multiple King Variants:
  TC: 10+0.1 | Concurrency: 12 | Variants: 3 | Adjudication: Disabled
  Elo: 24.2 +/- 4.6
  Record: 1067W - 837L - 1406D (3310 total)

Per-Variant Breakdown:
  [Double_King_Chess]: 533W - 507L - 386D, Elo: 6.3 +/- 7.9
  [Double_King_Classical]: 314W - 113L - 527D, Elo: 74.3 +/- 7.5
  [Triple_King_Maze]: 220W - 217L - 493D, Elo: 1.1 +/- 7.8
```

```
Default Variants (Non-regression test with bounds of [-10, 0]):
  TC: 10+0.1 | Concurrency: 12 | Variants: 15 | Adjudication: Disabled
  Elo: 6.7 +/- 4.7
  Record: 886W - 827L - 1327D (3040 total)
  ALERT: 1 games ended by timeout (NEW ENGINE ONLY)

Per-Variant Breakdown:
  [Classical]: 38W - 31L - 131D, Elo: 12.2 +/- 14.4
  [Classical_Plus]: 46W - 57L - 103D, Elo: -18.6 +/- 17.1
  [CoaIP]: 31W - 53L - 118D, Elo: -38.0 +/- 15.7
  [CoaIP_HO]: 61W - 67L - 78D, Elo: -10.1 +/- 19.1
  [CoaIP_NO]: 63W - 40L - 101D, Elo: 39.3 +/- 17.3
  [CoaIP_RO]: 69W - 41L - 92D, Elo: 48.5 +/- 18.1
  [Confined_Classical]: 77W - 58L - 69D, Elo: 32.5 +/- 19.8
  [Core]: 55W - 46L - 97D, Elo: 15.8 +/- 17.6
  [Knightline]: 90W - 100L - 12D, Elo: -17.2 +/- 23.7
  [Palace]: 103W - 90L - 13D, Elo: 22.0 +/- 23.5
  [Pawndard]: 35W - 29L - 136D, Elo: 10.4 +/- 13.9
  [Scattered_Leapers]: 22W - 22L - 160D, Elo: -0.0 +/- 11.3
  [Space]: 72W - 66L - 62D, Elo: 10.4 +/- 20.4
  [Space_Classic]: 73W - 80L - 51D, Elo: -11.9 +/- 21.1
  [Standarch]: 51W - 47L - 104D, Elo: 6.9 +/- 17.0
```