### PR TITLE
Account for minor fairy pieces

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -284,6 +284,23 @@ impl PieceType {
         )
     }
 
+    #[inline]
+    /// Check if this piece type is minor (more valuable than a pawn but less than a rook).
+    pub fn is_minor(&self) -> bool {
+        matches!(
+            self,
+            PieceType::Knight
+            | PieceType::Bishop
+            | PieceType::Camel
+            | PieceType::Zebra
+            | PieceType::Giraffe
+            | PieceType::Hawk
+            | PieceType::Centaur
+            | PieceType::Guard
+            | PieceType::Huygen
+        )
+    }
+
     /// Get all promotable piece types for dynamic promotion
     pub fn promotable_types() -> &'static [PieceType] {
         &[

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -661,7 +661,7 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                         let dx = (x - ek.x).abs();
                                         let dy = (y - ek.y).abs();
                                         if dx <= 20 && dy <= 20 {
-                                            let leaper_attack_units = if matches!(pt, PieceType::Rose) {
+                                            let leaper_attack_units = if matches!(pt, PieceType::Hawk | PieceType::Rose) {
                                                 100
                                             } else if matches!(
                                                 pt,

--- a/src/game.rs
+++ b/src/game.rs
@@ -1680,9 +1680,7 @@ impl GameState {
                 }
 
                 // Minor hash: Knights and Bishops
-                if piece.piece_type() == PieceType::Knight
-                    || piece.piece_type() == PieceType::Bishop
-                {
+                if piece.piece_type().is_minor() {
                     mih ^= piece_key(piece.piece_type(), piece.color(), x, y);
                 }
             }
@@ -3259,7 +3257,7 @@ impl GameState {
                 self.black_nonpawn_hash ^=
                     piece_key(piece.piece_type(), piece.color(), m.from.x, m.from.y);
             }
-            if piece.piece_type() == PieceType::Knight || piece.piece_type() == PieceType::Bishop {
+            if piece.piece_type().is_minor() {
                 self.minor_hash ^= piece_key(piece.piece_type(), piece.color(), m.from.x, m.from.y);
             }
         }
@@ -3324,9 +3322,7 @@ impl GameState {
                     self.black_nonpawn_hash ^=
                         piece_key(captured.piece_type(), captured.color(), m.to.x, m.to.y);
                 }
-                if captured.piece_type() == PieceType::Knight
-                    || captured.piece_type() == PieceType::Bishop
-                {
+                if captured.piece_type().is_minor() {
                     self.minor_hash ^=
                         piece_key(captured.piece_type(), captured.color(), m.to.x, m.to.y);
                 }
@@ -3565,9 +3561,7 @@ impl GameState {
                     m.to.y,
                 );
             }
-            if final_piece.piece_type() == PieceType::Knight
-                || final_piece.piece_type() == PieceType::Bishop
-            {
+            if final_piece.piece_type().is_minor() {
                 self.minor_hash ^= crate::search::zobrist::piece_key(
                     final_piece.piece_type(),
                     final_piece.color(),
@@ -3701,7 +3695,7 @@ impl GameState {
                 self.black_nonpawn_hash ^=
                     piece_key(piece.piece_type(), piece.color(), m.to.x, m.to.y);
             }
-            if piece.piece_type() == PieceType::Knight || piece.piece_type() == PieceType::Bishop {
+            if piece.piece_type().is_minor() {
                 self.minor_hash ^= piece_key(piece.piece_type(), piece.color(), m.to.x, m.to.y);
             }
         }
@@ -3748,7 +3742,7 @@ impl GameState {
                 self.black_nonpawn_hash ^=
                     piece_key(piece.piece_type(), piece.color(), m.from.x, m.from.y);
             }
-            if piece.piece_type() == PieceType::Knight || piece.piece_type() == PieceType::Bishop {
+            if piece.piece_type().is_minor() {
                 self.minor_hash ^= piece_key(piece.piece_type(), piece.color(), m.from.x, m.from.y);
             }
         }
@@ -3802,9 +3796,7 @@ impl GameState {
                         m.to.y,
                     );
                 }
-                if captured.piece_type() == PieceType::Knight
-                    || captured.piece_type() == PieceType::Bishop
-                {
+                if captured.piece_type().is_minor() {
                     self.minor_hash ^= crate::search::zobrist::piece_key(
                         captured.piece_type(),
                         captured.color(),


### PR DESCRIPTION
### Changes:
- Include hawks when calculating the tropism addend.
- Account for minor fairy pieces when computing the minor hash, which is used in minor piece correction history.
- The changes above should improve the engine by about **6–7 Elo.**