### PR TITLE
refactor: use see_ge in SEE pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -4372,8 +4372,7 @@ fn negamax(ctx: &mut NegamaxContext) -> i32 {
                         let see_margin = (see_capture_linear() * depth as i32
                             + capt_hist / see_capture_hist_div())
                         .max(0);
-                        let see_value = static_exchange_eval(game, &m);
-                        if see_value < -see_margin {
+                        if !see_ge(game, &m, -see_margin) {
                             continue;
                         }
                     }
@@ -4408,8 +4407,7 @@ fn negamax(ctx: &mut NegamaxContext) -> i32 {
                 // SEE pruning for quiets: skip moves with bad SEE
                 // Threshold: -25 * adj_lmr_depth²
                 let see_threshold = -see_quiet_quad() * adj_lmr_depth * adj_lmr_depth;
-                let see_value = static_exchange_eval(game, &m);
-                if see_value < see_threshold {
+                if !see_ge(game, &m, see_threshold) {
                     continue;
                 }
             }


### PR DESCRIPTION
This is just a small refactor of search.rs.
Note: The Elo bound used is [-8, 2].

SPRT result:
```
Final Summary:
  NEW: 40e5459 (2026-07-10, dirty)  vs  OLD: 40e5459 (2026-07-10)
  TC: 10+0.1 | Concurrency: 12 | Variants: 15 | Adjudication: Disabled
  Elo: 1.0 +/- 2.7
  Record: 2438W - 2412L - 4001D (8851 total)
  ALERT: 12 games ended by timeout (NEW ENGINE ONLY)

Per-Variant Breakdown:
  [Classical]: 117W - 117L - 350D, Elo: -0.0 +/- 9.1
  [Classical_Plus]: 158W - 156L - 282D, Elo: 1.2 +/- 10.3
  [CoaIP]: 106W - 111L - 378D, Elo: -2.9 +/- 8.6
  [CoaIP_HO]: 155W - 160L - 273D, Elo: -3.0 +/- 10.5
  [CoaIP_NO]: 154W - 149L - 283D, Elo: 3.0 +/- 10.3
  [CoaIP_RO]: 146W - 143L - 296D, Elo: 1.8 +/- 10.1
  [Confined_Classical]: 192W - 182L - 216D, Elo: 5.9 +/- 11.4
  [Core]: 166W - 181L - 243D, Elo: -8.8 +/- 11.0
  [Knightline]: 248W - 259L - 81D, Elo: -6.5 +/- 13.3
  [Palace]: 263W - 279L - 55D, Elo: -9.3 +/- 13.6
  [Pawndard]: 108W - 93L - 387D, Elo: 8.9 +/- 8.4
  [Scattered_Leapers]: 74W - 62L - 453D, Elo: 7.1 +/- 6.9
  [Space]: 195W - 168L - 231D, Elo: 15.8 +/- 11.1
  [Space_Classic]: 235W - 217L - 138D, Elo: 10.6 +/- 12.5
  [Standarch]: 121W - 135L - 335D, Elo: -8.2 +/- 9.4
```