### PR TITLE
feat: account for pinned pieces in SEE

### DIFF
--- a/src/search/see.rs
+++ b/src/search/see.rs
@@ -81,6 +81,65 @@ pub(crate) fn static_exchange_eval_impl(game: &GameState, m: &Move) -> i32 {
         None => (0, game.get_piece_value(m.piece.piece_type(), mover_color)),
     };
 
+    /// Helper function to determine if a piece can attack the target legally.
+    /// Accounts for pinned pieces.
+    #[inline(always)]
+    fn can_piece_legally_attack(
+        game: &GameState,
+        pos: &Coordinate,
+        target: &Coordinate,
+        color: PlayerColor,
+    ) -> bool {
+        // If the opponent's win condition does not require check evasion, then the piece can attack freely.
+        let opponent_win_condition = if color == PlayerColor::White {
+            game.game_rules.black_win_condition
+        } else {
+            game.game_rules.white_win_condition
+        };
+        if !opponent_win_condition.requires_check_evasion() {
+            return true
+        }
+
+        // Is there a king of the same color on the board?
+        let king_pos = if color == PlayerColor::White {
+            game.white_royals.first().copied()
+        } else {
+            game.black_royals.first().copied()
+        };
+        let Some(king) = king_pos else {
+            // No king - can't be pinned
+            return true;
+        };
+
+        // Is piece on a slider ray from king?
+        let dx = pos.x - king.x;
+        let dy = pos.y - king.y;
+
+        let on_slider_ray = dx == 0  // Vertical (same file)
+            || dy == 0               // Horizontal (same rank)  
+            || dx.abs() == dy.abs(); // Diagonal
+
+        if !on_slider_ray {
+            // Cannot be pinned
+            return true;
+        }
+
+        // If it's not pinned, it can attack, otherwise, check if the attack
+        // direction is on the same line with the pinned direction.
+        let pin_direction = if color == PlayerColor::White {
+            game.pinned_white.get(&(pos.x, pos.y))
+        } else {
+            game.pinned_black.get(&(pos.x, pos.y))
+        };
+
+        if let Some(&(pdx, pdy)) = pin_direction {
+            (target.x - pos.x) * pdy == (target.y - pos.y) * pdx
+        } else {
+            true
+        }
+    }
+
+    /// Represents an attacker looking on the target square.
     #[derive(Clone, Copy, Debug)]
     struct Attacker {
         value: i32,
@@ -313,7 +372,7 @@ pub(crate) fn static_exchange_eval_impl(game: &GameState, m: &Move) -> i32 {
             }
         }
 
-        if let Some(i) = best_i {
+        if let Some(mut i) = best_i {
             // A royal piece cannot recapture into a square the opponent still
             // defends (that would be moving into check). Since a royal's value is
             // the highest, it is only ever picked as the last attacker for its
@@ -324,6 +383,28 @@ pub(crate) fn static_exchange_eval_impl(game: &GameState, m: &Move) -> i32 {
             {
                 break;
             }
+
+            // If the piece is pinned, do a full rescan of the best attacker that is not pinned
+            if !can_piece_legally_attack(game, &attackers[i].pos, &m.to, attackers[i].color) {
+                let mut found_nothing = true;
+                best_val = i32::MAX;
+
+                for j in 0..attackers.len() {
+                    let a = &attackers[j];
+                    if a.color == side && a.value < best_val
+                        && can_piece_legally_attack(game, &a.pos, &m.to, a.color)
+                    {
+                        found_nothing = false;
+                        best_val = a.value;
+                        i = j;
+                    }
+                }
+
+                if found_nothing {
+                    break;
+                }
+            }
+
             let chosen = attackers.swap_remove(i);
             gain[depth] = occ_val - gain[depth - 1];
             occ_val = best_val;
@@ -620,6 +701,75 @@ mod tests {
             "Rook battery should win a rook through the vacated square"
         );
         assert!(see_ge(&game, &m, 0));
+    }
+
+    #[test]
+    fn test_see_pinned_piece_cannot_recapture() {
+        // White has a bishop on (1,5) and a rook on (3,3) that are looking at the
+        // black bishop on (3,7), which is only defended by the black queen at
+        // (3,8). However, the black bishop at (6,6) pins the white rook to the
+        // white king at (1,1), preventing it from recapturing the bishop because
+        // it would expose the king to check. Without pin detection, the black
+        // queen is captured by the pinned rook, which is an illegal move.
+        let mut game = create_test_game_from_icn("w (8;q|1;q) K1,1|R3,3|B1,5|b3,7|q3,8|k1,10|b6,6");
+        game.turn = PlayerColor::White;
+
+        let m = Move::new(
+            Coordinate::new(1, 5),
+            Coordinate::new(3, 7),
+            Piece::new(PieceType::Bishop, PlayerColor::White),
+        );
+
+        assert_eq!(
+            static_exchange_eval_impl(&game, &m),
+            0,
+            "The white rook is pinned to the white king; the black queen should take the bishop."
+        );
+    }
+
+    #[test]
+    fn test_see_piece_is_not_pinned_in_all_pieces_captured() {
+        // Same condition as the test above but this time, the rook is not pinned
+        // since the king can be captured in AllRoyalsCaptured win condition.
+        let mut game = create_test_game_from_icn("w (8;q|1;q) allroyalscaptured K1,1|R3,3|B1,5|b3,7|q3,8|k1,10|b6,6");
+        game.turn = PlayerColor::White;
+
+        let m = Move::new(
+            Coordinate::new(1, 5),
+            Coordinate::new(3, 7),
+            Piece::new(PieceType::Bishop, PlayerColor::White),
+        );
+
+        assert_ne!(
+            static_exchange_eval_impl(&game, &m),
+            0,
+            "The black queen should not take the bishop, because the rook is not pinned to the king in AllPiecesCaptured."
+        );
+    }
+
+    #[test]
+    fn test_see_pinned_piece_can_recapture_on_same_line() {
+        // White has a bishop on (1,5) and a rook on (3,3) that are looking at the
+        // black bishop on (3,7), which is only defended by the black queen at
+        // (3,8). It is fine for the white rook to take the black bishop because
+        // if the black queen takes, the white bishop can take the queen even if
+        // it's "pinned" to the king at (0,4) in the same pin direction.
+        let mut game = create_test_game_from_icn("w 1 (8;q|1;q) K0,4|R3,3|B1,5|b3,7|q3,8|k1,10");
+        game.turn = PlayerColor::White;
+
+        let m = Move::new(
+            Coordinate::new(3, 3),
+            Coordinate::new(3, 7),
+            Piece::new(PieceType::Rook, PlayerColor::White),
+        );
+
+        let b = game.get_piece_value(PieceType::Bishop, PlayerColor::White);
+        assert_eq!(
+            static_exchange_eval_impl(&game, &m),
+            b,
+            "The black queen should not take the bishop because the pinned white bishop can recapture the black queen, \
+            as it is in the same direction as the pin."
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Changes
- The engine now accounts for pinned pieces in `static_exchange_eval_impl`.
- To run faster, it does fast checks first to see if the piece can be pinned before doing a full check.
- Added 3 tests that account for pinned pieces.

### SPRT Results
```
Final Summary:
  NEW: 6ea67f3 (2026-07-14, dirty)  vs  OLD: 6ea67f3 (2026-07-14)
  TC: 10+0.1 | Concurrency: 12 | Variants: 15 | Adjudication: Disabled
  Elo: 6.0 +/- 2.4
  Record: 3071W - 2875L - 5323D (11269 total)
  ALERT: 16 games ended by timeout (NEW ENGINE ONLY)

Per-Variant Breakdown:
  [Classical]: 158W - 114L - 470D, Elo: 20.6 +/- 7.7
  [Classical_Plus]: 207W - 176L - 366D, Elo: 14.4 +/- 9.1
  [CoaIP]: 157W - 143L - 466D, Elo: 6.4 +/- 7.9
  [CoaIP_HO]: 165W - 189L - 394D, Elo: -11.2 +/- 8.7
  [CoaIP_NO]: 180W - 166L - 418D, Elo: 6.4 +/- 8.5
  [CoaIP_RO]: 190W - 166L - 385D, Elo: 11.3 +/- 8.8
  [Confined_Classical]: 221W - 233L - 312D, Elo: -5.4 +/- 9.7
  [Core]: 217W - 179L - 346D, Elo: 17.8 +/- 9.3
  [Knightline]: 335W - 335L - 94D, Elo: -0.0 +/- 11.8
  [Palace]: 341W - 334L - 71D, Elo: 3.3 +/- 12.1
  [Pawndard]: 115W - 112L - 514D, Elo: 1.4 +/- 7.1
  [Scattered_Leapers]: 87W - 87L - 574D, Elo: -0.0 +/- 6.1
  [Space]: 219W - 222L - 301D, Elo: -1.4 +/- 9.8
  [Space_Classic]: 308W - 266L - 174D, Elo: 19.5 +/- 11.1
  [Standarch]: 171W - 153L - 438D, Elo: 8.2 +/- 8.2
```

> [!NOTE]
> This commit is only tested in `base` variants. It does not include variants, such as Chess, Pawn Horde, Obstocean, and multi-king variants, although it is likely to pass here as well.