### PR TITLE
feat: generalize the outpost bonus to fairy pieces

### DIFF
--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -1562,18 +1562,16 @@ fn evaluate_pieces_processed<T: EvaluationTracer>(
                 white_pawns,
                 black_pawns,
             ),
-            PieceType::Knight => evaluate_knight(
-                x,
-                y,
-                piece.color(),
-                cloud_center.as_ref(),
-                cloud_avg_spread,
-                phase,
-                white_pawns,
-                black_pawns,
-            ),
-            PieceType::Hawk
+            // NOTE FOR KNIGHTRIDERS:
+            //   A knightrider rides along knight rays; on an unbounded board its
+            //   reach is unbounded so mobility-counting is meaningless. Use the
+            //   board-aware cloud-proximity/density shaping like the other riders.
+            PieceType::Knight
+            | PieceType::Guard
+            | PieceType::Hawk
             | PieceType::Rose
+            | PieceType::Huygen
+            | PieceType::Knightrider
             | PieceType::Camel
             | PieceType::Giraffe
             | PieceType::Zebra => evaluate_leaper_positioning(
@@ -1584,6 +1582,8 @@ fn evaluate_pieces_processed<T: EvaluationTracer>(
                 pt,
                 cloud_avg_spread,
                 phase,
+                white_pawns,
+                black_pawns,
             ),
             PieceType::Centaur | PieceType::RoyalCentaur => {
                 let leaper_eval = evaluate_leaper_positioning(
@@ -1594,39 +1594,11 @@ fn evaluate_pieces_processed<T: EvaluationTracer>(
                     pt,
                     cloud_avg_spread,
                     phase,
+                    white_pawns,
+                    black_pawns,
                 );
                 leaper_eval * CENTAUR_GUARD_SCALE / 100
             }
-            PieceType::Huygen => evaluate_leaper_positioning(
-                x,
-                y,
-                piece.color(),
-                cloud_center.as_ref(),
-                PieceType::Huygen,
-                cloud_avg_spread,
-                phase,
-            ),
-            PieceType::Guard => evaluate_leaper_positioning(
-                x,
-                y,
-                piece.color(),
-                cloud_center.as_ref(),
-                PieceType::Guard,
-                cloud_avg_spread,
-                phase,
-            ),
-            // A knightrider rides along knight rays; on an unbounded board its
-            // reach is unbounded so mobility-counting is meaningless. Use the
-            // board-aware cloud-proximity/density shaping like the other riders.
-            PieceType::Knightrider => evaluate_leaper_positioning(
-                x,
-                y,
-                piece.color(),
-                cloud_center.as_ref(),
-                PieceType::Knightrider,
-                cloud_avg_spread,
-                phase,
-            ),
             _ => 0,
         };
         let piece_val = get_piece_value_base(pt);
@@ -2318,10 +2290,7 @@ pub fn evaluate_bishop(
         y + 1
     };
 
-    // Check left support
     let has_left_support = my_pawns.binary_search(&(x - 1, support_y)).is_ok();
-
-    // Check right support
     let has_right_support = my_pawns.binary_search(&(x + 1, support_y)).is_ok();
 
     if has_left_support || has_right_support {
@@ -2331,69 +2300,25 @@ pub fn evaluate_bishop(
     bonus
 }
 
-fn evaluate_knight(
-    x: i64,
-    y: i64,
-    color: PlayerColor,
-    cloud_center: Option<&Coordinate>,
-    cloud_avg_spread: i32,
-    phase: i32,
-    white_pawns: &[(i64, i64)],
-    black_pawns: &[(i64, i64)],
-) -> i32 {
-    let taper =
-        |mg: i32, eg: i32| -> i32 { ((mg * phase) + (eg * (MAX_PHASE - phase))) / MAX_PHASE };
-    let mut bonus = evaluate_leaper_positioning(
-        x,
-        y,
-        color,
-        cloud_center,
-        PieceType::Knight,
-        cloud_avg_spread,
-        phase,
-    );
-
-    // Outpost Bonus: precise pawn support
-    let (my_pawns, _enemy_pawns) = if color == PlayerColor::White {
-        (white_pawns, black_pawns)
-    } else {
-        (black_pawns, white_pawns)
-    };
-
-    let support_y = if color == PlayerColor::White {
-        y - 1
-    } else {
-        y + 1
-    };
-
-    // Check left support
-    let has_left_support = my_pawns.binary_search(&(x - 1, support_y)).is_ok();
-
-    // Check right support
-    let has_right_support = my_pawns.binary_search(&(x + 1, support_y)).is_ok();
-
-    if has_left_support || has_right_support {
-        bonus += taper(mg_outpost_bonus(), eg_outpost_bonus());
-    }
-
-    bonus
-}
-
-/// Evaluate leaper pieces
+/// General piece evaluation for leapers
 ///
-/// Three components:
+/// Components:
 /// 1. **Cloud proximity** – reward being near the piece cloud center
 /// 2. **Density bonus** – leapers gain value when pieces cluster together
 /// 3. **Phase taper** – short-range leapers become relatively more valuable in the
 ///    endgame as the board empties
+/// 4. **Outpost bonus** – for minor leapers that have pawn support
+#[allow(clippy::too_many_arguments)]
 fn evaluate_leaper_positioning(
     x: i64,
     y: i64,
-    _color: PlayerColor,
+    color: PlayerColor,
     cloud_center: Option<&Coordinate>,
     piece_type: PieceType,
     cloud_avg_spread: i32,
     phase: i32,
+    white_pawns: &[(i64, i64)],
+    black_pawns: &[(i64, i64)],
 ) -> i32 {
     let taper =
         |mg: i32, eg: i32| -> i32 { ((mg * phase) + (eg * (MAX_PHASE - phase))) / MAX_PHASE };
@@ -2442,6 +2367,39 @@ fn evaluate_leaper_positioning(
         _ => (0, 10),
     };
     bonus += taper(mg_bonus, eg_bonus);
+
+    // 4. OUTPOST BONUS
+    if piece_type.is_minor() {
+        let my_pawns = if color == PlayerColor::White {
+            white_pawns
+        } else {
+            black_pawns
+        };
+
+        // Check for pawn support: (x-1, y-dir) or (x+1, y-dir)
+        // White pawns at y-1 support piece at y. Black pawns at y+1 support piece at y.
+        let support_y = if color == PlayerColor::White {
+            y - 1
+        } else {
+            y + 1
+        };
+
+        let has_left_support = my_pawns.binary_search(&(x - 1, support_y)).is_ok();
+        let has_right_support = my_pawns.binary_search(&(x + 1, support_y)).is_ok();
+
+        if has_left_support || has_right_support {
+            // Bonus = base * multiplier / 4
+            let bonus_multiplier = match piece_type {
+                PieceType::Knight | PieceType::Guard => 4,
+                PieceType::Camel | PieceType::Zebra | PieceType::Giraffe => 3,
+                PieceType::Huygen => 3,
+                PieceType::Centaur => 1,
+                PieceType::Hawk => 0,
+                _ => 0,
+            };
+            bonus += taper(mg_outpost_bonus(), eg_outpost_bonus()) * bonus_multiplier / 4;
+        }
+    }
 
     bonus
 }
@@ -3917,7 +3875,17 @@ mod tests {
         let icn_no_support = "w (8;q|1;q) K0,0|k0,10|N4,4";
         game.setup_position_from_icn(icn_no_support);
 
-        let score_no_support = evaluate_knight(4, 4, PlayerColor::White, None, 8, 0, &[], &[]);
+        let score_no_support = evaluate_leaper_positioning(
+            4,
+            4,
+            PlayerColor::White,
+            None,
+            PieceType::Knight,
+            8,
+            0,
+            &[],
+            &[],
+        );
 
         // Case 2: Support from pawn at (3,3) (White pawn at y-1 supports y)
         let icn_supported = "w (8;q|1;q) K0,0|k0,10|N4,4|P3,3";
@@ -3925,7 +3893,17 @@ mod tests {
         // Mock pawn list
         let white_pawns = vec![(3, 3)];
 
-        let score_supported = evaluate_knight(4, 4, PlayerColor::White, None, 8, 0, &white_pawns, &[]);
+        let score_supported = evaluate_leaper_positioning(
+            4,
+            4,
+            PlayerColor::White,
+            None,
+            PieceType::Knight,
+            8,
+            0,
+            &white_pawns,
+            &[],
+        );
 
         println!(
             "No Support: {}, Supported: {}",

--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -5,9 +5,10 @@ use smallvec::SmallVec;
 use std::cell::UnsafeCell;
 
 use crate::search::params::{
-    archbishop, bishop, camel, centaur, chancellor_bonus, eg_bishop_pair_bonus,
-    eg_doubled_pawn_penalty, eg_outpost_bonus, giraffe, guard, hawk, huygen, knight, knightrider,
-    mg_bishop_pair_bonus, mg_doubled_pawn_penalty, mg_outpost_bonus, pawn, queen_open_file_bonus,
+    archbishop, bishop, camel, centaur, chancellor_bonus, eg_bishop_outpost_bonus,
+    eg_bishop_pair_bonus, eg_doubled_pawn_penalty, eg_knight_outpost_bonus, giraffe, guard, hawk,
+    huygen, knight, knightrider, mg_bishop_outpost_bonus, mg_bishop_pair_bonus,
+    mg_doubled_pawn_penalty, mg_knight_outpost_bonus, pawn, queen_open_file_bonus,
     queen_semi_open_file_bonus, queen_value, rook, rook_open_file_bonus, rook_semi_open_file_bonus,
     rose, zebra,
 };
@@ -212,8 +213,10 @@ pub const DEFAULT_EVAL_ROOK_OPEN_FILE_BONUS: i32 = 45;
 pub const DEFAULT_EVAL_ROOK_SEMI_OPEN_FILE_BONUS: i32 = 20;
 pub const DEFAULT_EVAL_QUEEN_OPEN_FILE_BONUS: i32 = 25;
 pub const DEFAULT_EVAL_QUEEN_SEMI_OPEN_FILE_BONUS: i32 = 10;
-pub const DEFAULT_EVAL_MG_OUTPOST_BONUS: i32 = 20;
-pub const DEFAULT_EVAL_EG_OUTPOST_BONUS: i32 = 50;
+pub const DEFAULT_EVAL_MG_KNIGHT_OUTPOST_BONUS: i32 = 24;
+pub const DEFAULT_EVAL_EG_KNIGHT_OUTPOST_BONUS: i32 = 60;
+pub const DEFAULT_EVAL_MG_BISHOP_OUTPOST_BONUS: i32 = 18;
+pub const DEFAULT_EVAL_EG_BISHOP_OUTPOST_BONUS: i32 = 45;
 
 // Piece Values
 
@@ -2294,7 +2297,7 @@ pub fn evaluate_bishop(
     let has_right_support = my_pawns.binary_search(&(x + 1, support_y)).is_ok();
 
     if has_left_support || has_right_support {
-        bonus += taper(mg_outpost_bonus(), eg_outpost_bonus());
+        bonus += taper(mg_bishop_outpost_bonus(), eg_bishop_outpost_bonus());
     }
 
     bonus
@@ -2388,16 +2391,16 @@ fn evaluate_leaper_positioning(
         let has_right_support = my_pawns.binary_search(&(x + 1, support_y)).is_ok();
 
         if has_left_support || has_right_support {
-            // Bonus = base * multiplier / 4
-            let bonus_multiplier = match piece_type {
-                PieceType::Knight | PieceType::Guard => 4,
-                PieceType::Camel | PieceType::Zebra | PieceType::Giraffe => 3,
-                PieceType::Huygen => 3,
-                PieceType::Centaur => 1,
-                PieceType::Hawk => 0,
-                _ => 0,
+            let (mg_bonus, eg_bonus): (i32, i32) = match piece_type {
+                PieceType::Knight => (mg_knight_outpost_bonus(), eg_knight_outpost_bonus()),
+                PieceType::Guard => (22, 56),
+                PieceType::Camel | PieceType::Zebra | PieceType::Giraffe => (16, 40),
+                PieceType::Huygen => (16, 40),
+                PieceType::Centaur => (7, 17),
+                PieceType::Hawk => (0, 0),
+                _ => (6, 15),
             };
-            bonus += taper(mg_outpost_bonus(), eg_outpost_bonus()) * bonus_multiplier / 4;
+            bonus += taper(mg_bonus, eg_bonus);
         }
     }
 
@@ -3915,8 +3918,8 @@ mod tests {
         );
         assert_eq!(
             score_supported - score_no_support,
-            eg_outpost_bonus(),
-            "Bonus should match eg_outpost_bonus() in endgame"
+            eg_knight_outpost_bonus(),
+            "Bonus should match eg_knight_outpost_bonus() in endgame"
         );
     }
 

--- a/src/search/params.rs
+++ b/src/search/params.rs
@@ -187,8 +187,10 @@ pub const TUNABLE_EVAL_PARAM_SPECS: &[EvalParamSpec] = &[
     EvalParamSpec::new("rook_semi_open_file_bonus", crate::evaluation::base::DEFAULT_EVAL_ROOK_SEMI_OPEN_FILE_BONUS as i64, 0, 220, 2.0, 0.002, "Rook semi-open file bonus"),
     EvalParamSpec::new("queen_open_file_bonus", crate::evaluation::base::DEFAULT_EVAL_QUEEN_OPEN_FILE_BONUS as i64, 0, 225, 2.0, 0.002, "Queen open file bonus"),
     EvalParamSpec::new("queen_semi_open_file_bonus", crate::evaluation::base::DEFAULT_EVAL_QUEEN_SEMI_OPEN_FILE_BONUS as i64, 0, 210, 2.0, 0.002, "Queen semi-open file bonus"),
-    EvalParamSpec::new("mg_outpost_bonus", crate::evaluation::base::DEFAULT_EVAL_MG_OUTPOST_BONUS as i64, 0, 220, 2.0, 0.002, "Middlegame outpost bonus"),
-    EvalParamSpec::new("eg_outpost_bonus", crate::evaluation::base::DEFAULT_EVAL_EG_OUTPOST_BONUS as i64, 0, 250, 2.0, 0.002, "Endgame outpost bonus"),
+    EvalParamSpec::new("mg_knight_outpost_bonus", crate::evaluation::base::DEFAULT_EVAL_MG_KNIGHT_OUTPOST_BONUS as i64, 0, 220, 2.0, 0.002, "Middlegame outpost bonus"),
+    EvalParamSpec::new("eg_knight_outpost_bonus", crate::evaluation::base::DEFAULT_EVAL_EG_KNIGHT_OUTPOST_BONUS as i64, 0, 250, 2.0, 0.002, "Endgame outpost bonus"),
+    EvalParamSpec::new("mg_bishop_outpost_bonus", crate::evaluation::base::DEFAULT_EVAL_MG_BISHOP_OUTPOST_BONUS as i64, 0, 220, 2.0, 0.002, "Middlegame outpost bonus"),
+    EvalParamSpec::new("eg_bishop_outpost_bonus", crate::evaluation::base::DEFAULT_EVAL_EG_BISHOP_OUTPOST_BONUS as i64, 0, 250, 2.0, 0.002, "Endgame outpost bonus"),
 ];
 
 #[cfg(any(feature = "param_tuning", feature = "eval_tuning"))]
@@ -219,8 +221,10 @@ pub struct EvalParams {
     pub rook_semi_open_file_bonus: i32,
     pub queen_open_file_bonus: i32,
     pub queen_semi_open_file_bonus: i32,
-    pub mg_outpost_bonus: i32,
-    pub eg_outpost_bonus: i32,
+    pub mg_knight_outpost_bonus: i32,
+    pub eg_knight_outpost_bonus: i32,
+    pub mg_bishop_outpost_bonus: i32,
+    pub eg_bishop_outpost_bonus: i32,
 }
 
 #[cfg(any(feature = "param_tuning", feature = "eval_tuning"))]
@@ -251,8 +255,10 @@ impl Default for EvalParams {
             rook_semi_open_file_bonus: crate::evaluation::base::DEFAULT_EVAL_ROOK_SEMI_OPEN_FILE_BONUS,
             queen_open_file_bonus: crate::evaluation::base::DEFAULT_EVAL_QUEEN_OPEN_FILE_BONUS,
             queen_semi_open_file_bonus: crate::evaluation::base::DEFAULT_EVAL_QUEEN_SEMI_OPEN_FILE_BONUS,
-            mg_outpost_bonus: crate::evaluation::base::DEFAULT_EVAL_MG_OUTPOST_BONUS,
-            eg_outpost_bonus: crate::evaluation::base::DEFAULT_EVAL_EG_OUTPOST_BONUS,
+            mg_knight_outpost_bonus: crate::evaluation::base::DEFAULT_EVAL_MG_KNIGHT_OUTPOST_BONUS,
+            eg_knight_outpost_bonus: crate::evaluation::base::DEFAULT_EVAL_EG_KNIGHT_OUTPOST_BONUS,
+            mg_bishop_outpost_bonus: crate::evaluation::base::DEFAULT_EVAL_MG_BISHOP_OUTPOST_BONUS,
+            eg_bishop_outpost_bonus: crate::evaluation::base::DEFAULT_EVAL_EG_BISHOP_OUTPOST_BONUS,
         }
     }
 }
@@ -327,8 +333,10 @@ define_eval_accessor!(rook_open_file_bonus, crate::evaluation::base::DEFAULT_EVA
 define_eval_accessor!(rook_semi_open_file_bonus, crate::evaluation::base::DEFAULT_EVAL_ROOK_SEMI_OPEN_FILE_BONUS);
 define_eval_accessor!(queen_open_file_bonus, crate::evaluation::base::DEFAULT_EVAL_QUEEN_OPEN_FILE_BONUS);
 define_eval_accessor!(queen_semi_open_file_bonus, crate::evaluation::base::DEFAULT_EVAL_QUEEN_SEMI_OPEN_FILE_BONUS);
-define_eval_accessor!(mg_outpost_bonus, crate::evaluation::base::DEFAULT_EVAL_MG_OUTPOST_BONUS);
-define_eval_accessor!(eg_outpost_bonus, crate::evaluation::base::DEFAULT_EVAL_EG_OUTPOST_BONUS);
+define_eval_accessor!(mg_knight_outpost_bonus, crate::evaluation::base::DEFAULT_EVAL_MG_KNIGHT_OUTPOST_BONUS);
+define_eval_accessor!(eg_knight_outpost_bonus, crate::evaluation::base::DEFAULT_EVAL_EG_KNIGHT_OUTPOST_BONUS);
+define_eval_accessor!(mg_bishop_outpost_bonus, crate::evaluation::base::DEFAULT_EVAL_MG_BISHOP_OUTPOST_BONUS);
+define_eval_accessor!(eg_bishop_outpost_bonus, crate::evaluation::base::DEFAULT_EVAL_EG_BISHOP_OUTPOST_BONUS);
 
 #[inline]
 pub fn queen_value() -> i32 {

--- a/src/search/zobrist.rs
+++ b/src/search/zobrist.rs
@@ -180,7 +180,7 @@ pub fn material_key(piece_type: PieceType, color: PlayerColor) -> u64 {
 #[inline(always)]
 pub fn material_key_at(piece_type: PieceType, color: PlayerColor, x: i64, y: i64) -> u64 {
     let k = material_key(piece_type, color);
-    if piece_type == PieceType::Bishop && (x + y).rem_euclid(2) == 1 {
+    if piece_type == PieceType::Bishop && ((x + y) & 1) == 1 {
         k.rotate_left(17)
     } else {
         k


### PR DESCRIPTION
### Change:
Some of the fairy pieces now have an outpost bonus. It removes the need for the `evaluate_knight()` function, as `evaluate_leaper_positioning()` is already accounting for all positional aspects of the knight.

### Things to do:
- [x] Implement outpost bonus for fairy pieces
- [x] Manually fine-tune the outpost bonus of knights and bishops
- [x] Manually fine-tune the outpost bonus of fairy pieces
- [ ] Get the latest version of the engine
- [ ] Test with SPRT