### PR TITLE
sprt: alert on engine failure and illegal move in final summary

### DIFF
--- a/src/bin/sprt.rs
+++ b/src/bin/sprt.rs
@@ -2286,6 +2286,8 @@ fn main() {
             let mut draws = 0;
             let mut penta = PentaCounts::default();
             let mut timeout_losses = 0;
+            let mut engine_failures = 0;
+            let mut illegal_moves = 0;
             let mut game_logs: Vec<String> = Vec::new();
             let mut per_variant_stats: HashMap<String, (usize, usize, usize)> = HashMap::new();
             let mut last_status_len = 0;
@@ -2441,6 +2443,16 @@ fn main() {
                             );
                         }
                     }
+                    if outcome.termination_reason == "engine failure"
+                        && outcome.result == GameResult::Loss
+                    {
+                        engine_failures += 1;
+                    }
+                    if outcome.termination_reason == "illegal move"
+                        && outcome.result == GameResult::Loss
+                    {
+                        illegal_moves += 1;
+                    }
 
                     match outcome.result {
                         GameResult::Win => wins += 1,
@@ -2580,6 +2592,12 @@ fn main() {
 
             if timeout_losses > 0 {
                 println!("{red}  ALERT: {timeout_losses} games ended by timeout (NEW ENGINE ONLY) {reset}");
+            }
+            if engine_failures > 0 {
+                println!("{red}  ALERT: {engine_failures} games ended by engine failure (NEW ENGINE ONLY) {reset}");
+            }
+            if illegal_moves > 0 {
+                println!("{red}  ALERT: {illegal_moves} games ended by illegal move (NEW ENGINE ONLY) {reset}");
             }
             println!("\nPer-Variant Breakdown:");
             let mut variant_names: Vec<_> = per_variant_stats.keys().collect();


### PR DESCRIPTION
A loss on engine failure or illegal move is as much a red flag as a loss on time, but neither was surfaced anywhere in the SPRT summary — you had to grep the games JSON for the `Termination` tag to notice. Both now get an ALERT line beside the existing timeout alert.

Only the new engine's faults are counted, matching the timeout alert. A faulting engine always loses the game, so `result == Loss` identifies it with no extra plumbing.

```
Final Summary:
  NEW: 89cbfd0 (2026-08-14, dirty)  vs  OLD: a0512a8 (2026-08-13)
  TC: 10+0.1 | Concurrency: 12 | Variants: 17 | Strength: 8 vs 8 | Adjudication: 15000 cp
  nElo: -190.30 +/- 139.00
  Elo: -88.7 +/- 68.7
  Record: 9W - 12L - 8D (29 total)
  Pentanomial [12 pairs]: LL:1 LD:4 WL/DD:7 WD:0 WW:0
  LLR: -0.049  bounds [-2.94, 2.94] (normalized model, [0, 2])
  ALERT: 1 games ended by engine failure (NEW ENGINE ONLY)
```

Note that `engine failure` is the existing catch-all for "no usable `bestmove` in a non-terminal position", so a panic and a clean exit with no move are indistinguishable here; separating them would need the harness to record the subprocess exit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
