### PR TITLE
eval: adjust attack readiness values

### DIFF
--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -2098,17 +2098,24 @@ fn compute_attack_readiness_optimized(
     }
 
     let total_open_rays = open_diag_rays + open_ortho_rays;
-    if total_open_rays <= 2 {
-        return 40;
-    }
 
     // Scoring logic (Simplified from calculate_attack_readiness_from_list)
-    if sliders_in_zone >= 2 {
-        100
-    } else if sliders_in_zone == 1 && total_open_rays >= 5 {
-        85
-    } else if sliders_in_zone == 1 {
-        55
+    if sliders_in_zone >= 3 {
+        if total_open_rays >= 3 {
+            100
+        } else {
+            40
+        }
+    } else if sliders_in_zone >= 1 {
+        if total_open_rays >= 5 {
+            85
+        } else if total_open_rays >= 3 {
+            55
+        } else {
+            40
+        }
+    } else if total_open_rays >= 3 {
+        40
     } else {
         30
     }


### PR DESCRIPTION
### Change:
This also fixes the previous code where attack readiness is lower when there are more than 2 open rays when there are no sliders in zone.

### SPRT Results:
```
Final Summary:
  NEW: e1641e9 (2026-08-16, dirty)  vs  OLD: e1641e9 (2026-08-16)
  TC: 10+0.1 | Concurrency: 12 | Variants: 15 | Strength: 8 vs 8 | Adjudication: Disabled
  nElo: 21.05 +/- 10.94
  Elo: 16.4 +/- 8.6
  Record: 1502W - 1319L - 1051D (3872 total)
  Pentanomial [1936 pairs]: LL:180 LD:315 WL/DD:823 WD:378 WW:240
  LLR: 2.963  bounds [-2.94, 2.94] (normalized model, [0, 5])
  ALERT: 1 games ended by timeout (NEW ENGINE ONLY)

Per-Variant Breakdown:
  [Classical]: 65W - 49L - 134D, Elo: 22.4 +/- 15.0
  [Classical_Plus]: 105W - 76L - 81D, Elo: 38.6 +/- 17.9
  [CoaIP]: 92W - 104L - 72D, Elo: -15.6 +/- 18.2
  [CoaIP_HO]: 96W - 113L - 51D, Elo: -22.7 +/- 19.3
  [CoaIP_NO]: 130W - 87L - 51D, Elo: 56.2 +/- 19.3
  [CoaIP_RO]: 99W - 80L - 67D, Elo: 26.9 +/- 18.9
  [Confined_Classical]: 93W - 93L - 84D, Elo: -0.0 +/- 17.5
  [Core]: 101W - 78L - 67D, Elo: 32.6 +/- 18.9
  [Knightline]: 127W - 113L - 30D, Elo: 18.0 +/- 20.0
  [Palace]: 128W - 116L - 16D, Elo: 16.0 +/- 20.9
  [Pawndard]: 76W - 58L - 110D, Elo: 25.7 +/- 16.5
  [Scattered_Leapers]: 76W - 80L - 102D, Elo: -5.4 +/- 16.8
  [Space]: 92W - 100L - 54D, Elo: -11.3 +/- 19.6
  [Space_Classic]: 116W - 95L - 47D, Elo: 28.3 +/- 19.6
  [Standarch]: 106W - 77L - 85D, Elo: 37.7 +/- 17.6
```