### PR TITLE
eval: gradual pawn far from the promotion penalty

### DIFF
--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -16,7 +16,7 @@ use crate::search::params::{
     mg_doubled_pawn_penalty, mg_far_slider_penalty_mult, mg_king_pawn_ahead_penalty,
     mg_outpost_bonus, min_major_development_penalty,
     minor_development_penalty_threshold, passed_enemy_king_dist, passed_friendly_king_dist,
-    passed_pawn_adv_bonus, pawn, pawn_enemy_king_dist, pawn_far_from_promo_penalty,
+    passed_pawn_adv_bonus, pawn, pawn_enemy_king_dist, pawn_far_from_promo_max_penalty,
     pawn_friendly_king_dist, pawn_full_value_threshold, pawn_past_promo_penalty,
     piece_cloud_cheb_max_excess, piece_cloud_cheb_radius, queen_ideal_line_dist,
     queen_open_file_bonus, queen_semi_open_file_bonus, queen_value, rook, rook_open_file_bonus,
@@ -303,7 +303,7 @@ pub const DEFAULT_EVAL_AMAZON_QUEEN_SCALE: i32 = 70;
 pub const DEFAULT_EVAL_CENTAUR_GUARD_SCALE: i32 = 50;
 pub const DEFAULT_EVAL_PAWN_FULL_VALUE_THRESHOLD: i32 = 6;
 pub const DEFAULT_EVAL_PAWN_PAST_PROMO_PENALTY: i32 = 90;
-pub const DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_PENALTY: i32 = 48;
+pub const DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_MAX_PENALTY: i32 = 100;
 pub const DEFAULT_EVAL_MINOR_DEVELOPMENT_PENALTY_THRESHOLD: i32 = 400;
 pub const DEFAULT_EVAL_MIN_MAJOR_DEVELOPMENT_PENALTY: i32 = 16;
 pub const DEFAULT_EVAL_MIN_FAIRY_DEVELOPMENT_PENALTY: i32 = 80;
@@ -1228,14 +1228,10 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                             w_pawn_penalty -= pawn_past_promo_penalty();
                                         } else {
                                             let dist = w_promo - y;
-                                            if dist > pawn_full_value_threshold() as i64 {
-                                                w_pawn_bonus -= pawn_far_from_promo_penalty();
-                                            } else {
-                                                w_pawn_bonus += (pawn_full_value_threshold() as i64
-                                                    - dist)
-                                                    as i32
-                                                    * 6;
-                                            }
+                                            let bonus =
+                                                (pawn_full_value_threshold() - dist.min(255) as i32) * 6;
+
+                                            w_pawn_bonus += bonus.max(-pawn_far_from_promo_max_penalty());
                                             if y > white_max_y {
                                                 white_max_y = y;
                                             }
@@ -1271,14 +1267,10 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                             b_pawn_penalty -= pawn_past_promo_penalty();
                                         } else {
                                             let dist = y - b_promo;
-                                            if dist > pawn_full_value_threshold() as i64 {
-                                                b_pawn_bonus -= pawn_far_from_promo_penalty();
-                                            } else {
-                                                b_pawn_bonus += (pawn_full_value_threshold() as i64
-                                                    - dist)
-                                                    as i32
-                                                    * 6;
-                                            }
+                                            let bonus =
+                                                (pawn_full_value_threshold() - dist.min(255) as i32) * 6;
+
+                                            b_pawn_bonus += bonus.max(-pawn_far_from_promo_max_penalty());
                                             if y < black_min_y {
                                                 black_min_y = y;
                                             }

--- a/src/search/params.rs
+++ b/src/search/params.rs
@@ -223,7 +223,7 @@ pub const TUNABLE_EVAL_PARAM_SPECS: &[EvalParamSpec] = &[
     EvalParamSpec::new("centaur_guard_scale", crate::evaluation::base::DEFAULT_EVAL_CENTAUR_GUARD_SCALE as i64, 10, 120, 2.0, 0.002, "Centaur guard/leaper-component scale (% of guard eval)"),
     EvalParamSpec::new("pawn_full_value_threshold", crate::evaluation::base::DEFAULT_EVAL_PAWN_FULL_VALUE_THRESHOLD as i64, 2, 16, 2.0, 0.002, "Ranks from promotion within which a pawn keeps full value"),
     EvalParamSpec::new("pawn_past_promo_penalty", crate::evaluation::base::DEFAULT_EVAL_PAWN_PAST_PROMO_PENALTY as i64, 0, 250, 2.0, 0.002, "Penalty for a pawn that can never promote"),
-    EvalParamSpec::new("pawn_far_from_promo_penalty", crate::evaluation::base::DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_PENALTY as i64, 0, 150, 2.0, 0.002, "Flat penalty for a pawn far from promotion"),
+    EvalParamSpec::new("pawn_far_from_promo_max_penalty", crate::evaluation::base::DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_MAX_PENALTY as i64, 0, 150, 2.0, 0.002, "Max penalty for a pawn far from promotion"),
     EvalParamSpec::new("minor_development_penalty_threshold", crate::evaluation::base::DEFAULT_EVAL_MINOR_DEVELOPMENT_PENALTY_THRESHOLD as i64, 100, 800, 4.0, 0.002, "Piece value below which the stronger undeveloped-minor penalty applies"),
     EvalParamSpec::new("min_major_development_penalty", crate::evaluation::base::DEFAULT_EVAL_MIN_MAJOR_DEVELOPMENT_PENALTY as i64, 0, 30, 2.0, 0.002, "Undeveloped-major penalty"),
     EvalParamSpec::new("min_fairy_development_penalty", crate::evaluation::base::DEFAULT_EVAL_MIN_FAIRY_DEVELOPMENT_PENALTY as i64, 0, 220, 2.0, 0.002, "Undeveloped-fairy-leaper penalty (leapers are worthless at home, knights and bishops are not)"),
@@ -359,7 +359,7 @@ pub struct EvalParams {
     pub centaur_guard_scale: i32,
     pub pawn_full_value_threshold: i32,
     pub pawn_past_promo_penalty: i32,
-    pub pawn_far_from_promo_penalty: i32,
+    pub pawn_far_from_promo_max_penalty: i32,
     pub minor_development_penalty_threshold: i32,
     pub min_major_development_penalty: i32,
     pub min_fairy_development_penalty: i32,
@@ -497,7 +497,7 @@ impl Default for EvalParams {
             centaur_guard_scale: crate::evaluation::base::DEFAULT_EVAL_CENTAUR_GUARD_SCALE,
             pawn_full_value_threshold: crate::evaluation::base::DEFAULT_EVAL_PAWN_FULL_VALUE_THRESHOLD,
             pawn_past_promo_penalty: crate::evaluation::base::DEFAULT_EVAL_PAWN_PAST_PROMO_PENALTY,
-            pawn_far_from_promo_penalty: crate::evaluation::base::DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_PENALTY,
+            pawn_far_from_promo_max_penalty: crate::evaluation::base::DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_MAX_PENALTY,
             minor_development_penalty_threshold: crate::evaluation::base::DEFAULT_EVAL_MINOR_DEVELOPMENT_PENALTY_THRESHOLD,
             min_major_development_penalty: crate::evaluation::base::DEFAULT_EVAL_MIN_MAJOR_DEVELOPMENT_PENALTY,
             min_fairy_development_penalty: crate::evaluation::base::DEFAULT_EVAL_MIN_FAIRY_DEVELOPMENT_PENALTY,
@@ -800,7 +800,7 @@ define_eval_accessor!(amazon_queen_scale, crate::evaluation::base::DEFAULT_EVAL_
 define_eval_accessor!(centaur_guard_scale, crate::evaluation::base::DEFAULT_EVAL_CENTAUR_GUARD_SCALE);
 define_eval_accessor!(pawn_full_value_threshold, crate::evaluation::base::DEFAULT_EVAL_PAWN_FULL_VALUE_THRESHOLD);
 define_eval_accessor!(pawn_past_promo_penalty, crate::evaluation::base::DEFAULT_EVAL_PAWN_PAST_PROMO_PENALTY);
-define_eval_accessor!(pawn_far_from_promo_penalty, crate::evaluation::base::DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_PENALTY);
+define_eval_accessor!(pawn_far_from_promo_max_penalty, crate::evaluation::base::DEFAULT_EVAL_PAWN_FAR_FROM_PROMO_MAX_PENALTY);
 define_eval_accessor!(minor_development_penalty_threshold, crate::evaluation::base::DEFAULT_EVAL_MINOR_DEVELOPMENT_PENALTY_THRESHOLD);
 define_eval_accessor!(min_major_development_penalty, crate::evaluation::base::DEFAULT_EVAL_MIN_MAJOR_DEVELOPMENT_PENALTY);
 define_eval_accessor!(min_fairy_development_penalty, crate::evaluation::base::DEFAULT_EVAL_MIN_FAIRY_DEVELOPMENT_PENALTY);


### PR DESCRIPTION
### Changes:
The pawn relative rank bonus/penalty has been extended to account for pawns more than 6 ranks away from promotion, capping at -100 cp.

### SPRT Results:
Tested in `base_only` variants excluding those with all pawns at most 6 ranks away from promotion.
```
Final Summary:
  NEW: 69eb256 (2026-08-19, dirty)  vs  OLD: 69eb256 (2026-08-19)
  TC: 10+0.1 | Concurrency: 6 | Variants: 11 | Strength: 8 vs 8 | Adjudication: Off | Max-ply adjudication: 1000 cp
  Elo: 20.24 +/- 9.91
  nElo: 24.23 +/- 11.83
  Games: 3316 | W: 1296 L: 1103 D: 917
  Pentanomial [1658 pairs] (0-2): 183, 282, 591, 363, 239
  LLR: 2.964  bounds [-2.94, 2.94] (normalized model, [0, 5])

Per-Variant Breakdown:
  [Classical_Plus]: 119W - 94L - 91D, Elo: 28.6 +/- 16.7
  [CoaIP]: 110W - 109L - 83D, Elo: 1.2 +/- 17.0
  [CoaIP_HO]: 121W - 109L - 72D, Elo: 13.8 +/- 17.5
  [CoaIP_NO]: 119W - 118L - 65D, Elo: 1.2 +/- 17.7
  [CoaIP_RO]: 120W - 114L - 66D, Elo: 6.9 +/- 17.7
  [Core]: 121W - 102L - 77D, Elo: 22.0 +/- 17.3
  [Pawndard]: 99W - 70L - 135D, Elo: 33.2 +/- 14.9
  [Scattered_Leapers]: 94W - 91L - 117D, Elo: 3.5 +/- 15.6
  [Space]: 123W - 119L - 58D, Elo: 4.6 +/- 18.0
  [Space_Classic]: 150W - 94L - 56D, Elo: 65.6 +/- 18.3
  [Standarch]: 120W - 83L - 97D, Elo: 43.1 +/- 16.6
```