### PR TITLE
perf: faster evaluate_knightrider_reach

### DIFF
--- a/src/evaluation/piece_reach.rs
+++ b/src/evaluation/piece_reach.rs
@@ -198,16 +198,6 @@ pub(crate) fn evaluate_rose_reach(
     attack + taper(defend, defend / 2)
 }
 
-#[inline]
-fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
-    while b != 0 {
-        let t = a % b;
-        a = b;
-        b = t;
-    }
-    a
-}
-
 /// Mirrors knightrider movegen: each ray stops at its closest occupant, and a
 /// capture is emitted at any distance while quiets cap out. One gcd places a
 /// piece on its ray, since k = gcd(|rx|, |ry|) for a reduced knight step.
@@ -226,31 +216,21 @@ pub(crate) fn evaluate_knightrider_reach(
 
     for &(px, py, other) in piece_list {
         let (rx, ry) = (px - x, py - y);
-        if rx == 0 && ry == 0 {
+        let (dx, dy) = (rx.abs(), ry.abs());
+
+        // Only check pieces that are on knightrider's rays.
+        if dx == 0 || (dx * 2 != dy && dx != dy * 2) {
             continue;
         }
-        let g = gcd_i64(rx.abs(), ry.abs());
-        if g == 0 {
-            continue;
-        }
-        let (ux, uy) = (rx / g, ry / g);
-        let (au, av) = (ux.abs(), uy.abs());
-        if !((au == 1 && av == 2) || (au == 2 && av == 1)) {
-            continue;
-        }
-        let slot = match (ux, uy) {
-            (1, 2) => 0,
-            (1, -2) => 1,
-            (2, 1) => 2,
-            (2, -1) => 3,
-            (-1, 2) => 4,
-            (-1, -2) => 5,
-            (-2, 1) => 6,
-            (-2, -1) => 7,
-            _ => continue,
-        };
-        if g < best_k[slot] {
-            best_k[slot] = g;
+
+        let slot = 4 * (rx > 0) as usize
+            + 2 * (ry > 0) as usize
+            + (dx > dy) as usize;
+
+        // It only needs to check the minimum dx since it's always a multiple of
+        // either 1 or 2 depending on the slot.
+        if dx < best_k[slot] {
+            best_k[slot] = dx;
             best[slot] = Some(other);
         }
     }


### PR DESCRIPTION
### Change:
This implements a faster way of assigning a slot to a piece on the
knightrider's rays.

### Results:

Ran a search-only suite for Apeiron (depth 11, average of 5 runs) for 2
variants. The change yielded about **+6.6%** speed improvement.
- CoaIP_NO: 92.3k → 98.3k NPS
- Scattered_Leapers: 113.4k → 120.9k NPS

**SPRT Results:**
```
Final Summary:
  NEW: a2e6899 (2026-08-26, dirty)  vs  OLD: a2e6899 (2026-08-26)
  TC: 10+0.1 | Concurrency: 6 | Variants: 2 | Strength: 8 vs 8
  Adjudication: Off | Max-ply adjudication: 1000 cp
  Elo: 11.04 +/- 8.14
  nElo: 13.27 +/- 9.78
  Games: 4850 | W: 1746 L: 1592 D: 1512
  Pentanomial [2425 pairs] (0-2): 269, 479, 823, 537, 317
  LLR: 2.963  bounds [-2.94, 2.94] (normalized model, [-4, 1])
  ALERT: 5 games ended by timeout (2 from new)

Per-Variant Breakdown:
  [CoaIP_NO]: 1027W - 928L - 621D, Elo: 13.4 +/- 6.0
  [Scattered_Leapers]: 719W - 664L - 891D, Elo: 8.4 +/- 5.7
```