### PR TITLE
eval: give the pawn a threat gradient

### DIFF
--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -799,13 +799,11 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
         .collect();
 
     // Interaction threat constants
-    const PAWN_THREATENS_MINOR: i32 = 25;
-    const PAWN_THREATENS_ROOK: i32 = 40;
-    const PAWN_THREATENS_QUEEN: i32 = 60;
+    const PAWN_THREATENS_ROYAL: i32 = 20;
+    const MINOR_THREATENS_ROYAL: i32 = 20;
     // Sliders are graded by value gap rather than bucketed: on an unbounded
     // board they are the pieces that can threaten from anywhere, and a fixed
     // tier would have to be re-cut every time the piece values are refitted.
-    const MINOR_THREATENS_ROYAL: i32 = 20;
 
     const KNIGHT_OFFSETS: [(i64, i64); 8] = [
         (2, 1),
@@ -1078,25 +1076,20 @@ pub fn evaluate_inner_traced<T: EvaluationTracer>(game: &GameState, tracer: &mut
                                             dy,
                                         ) && target.color() == enemy
                                         {
-                                            let tv = get_piece_value_base(target.piece_type());
-                                            if tv >= 600 {
-                                                if is_white {
-                                                    w_pawn_threats += PAWN_THREATENS_QUEEN;
-                                                } else {
-                                                    b_pawn_threats += PAWN_THREATENS_QUEEN;
-                                                }
-                                            } else if tv >= 400 {
-                                                if is_white {
-                                                    w_pawn_threats += PAWN_THREATENS_ROOK;
-                                                } else {
-                                                    b_pawn_threats += PAWN_THREATENS_ROOK;
-                                                }
-                                            } else if tv >= 200 {
-                                                if is_white {
-                                                    w_pawn_threats += PAWN_THREATENS_MINOR;
-                                                } else {
-                                                    b_pawn_threats += PAWN_THREATENS_MINOR;
-                                                }
+                                            let tt = target.piece_type();
+                                            let tv = get_piece_value_base(tt);
+                                            let add = if tt.is_royal() {
+                                                PAWN_THREATENS_ROYAL
+                                            } else {
+                                                let raw = (tv - piece_val).max(0);
+                                                (raw / slider_threat_div())
+                                                    .min(slider_threat_cap())
+                                            };
+
+                                            if is_white {
+                                                w_pawn_threats += add;
+                                            } else {
+                                                b_pawn_threats += add;
                                             }
                                         }
                                     }


### PR DESCRIPTION
### Change:
The threat bonus of pawns now scales the same way as the knight, the sliders, and other pieces instead of using 3 buckets.

### SPRT Results:
```
Final Summary:
  NEW: a0aab63 (2026-08-29, dirty)  vs  OLD: a0aab63 (2026-08-29)
  TC: 10+0.1 | Concurrency: 6 | Variants: 15 | Strength: 8 vs 8
  Material adjudication: Off | Max-ply adjudication: 1000 cp
  Elo: 19.70 +/- 9.83
  nElo: 23.25 +/- 11.58
  Games: 3460 | W: 1338 L: 1142 D: 980
  Pentanomial [1730 pairs] (0-2): 199, 298, 599, 376, 258
  LLR: 2.956  bounds [-2.94, 2.94] (normalized model, [0, 5])
  ALERT: 2 games ended by timeout (2 from new)

Per-Variant Breakdown:
  [Classical]: 62W - 42L - 120D, Elo: 31.1 +/- 15.8
  [Classical_Plus]: 92W - 80L - 66D, Elo: 17.5 +/- 19.2
  [CoaIP]: 95W - 71L - 68D, Elo: 35.8 +/- 19.2
  [CoaIP_HO]: 106W - 76L - 54D, Elo: 44.4 +/- 20.0
  [CoaIP_NO]: 78W - 92L - 62D, Elo: -21.0 +/- 19.5
  [CoaIP_RO]: 89W - 77L - 56D, Elo: 18.8 +/- 20.2
  [Confined_Classical]: 78W - 78L - 78D, Elo: -0.0 +/- 18.5
  [Core]: 98W - 68L - 56D, Elo: 47.2 +/- 20.3
  [Knightline]: 97W - 108L - 27D, Elo: -16.5 +/- 21.5
  [Palace]: 113W - 104L - 19D, Elo: 13.3 +/- 21.7
  [Pawndard]: 81W - 50L - 91D, Elo: 48.8 +/- 18.0
  [Scattered_Leapers]: 75W - 56L - 105D, Elo: 28.0 +/- 16.9
  [Space]: 91W - 85L - 46D, Elo: 9.4 +/- 20.8
  [Space_Classic]: 101W - 84L - 51D, Elo: 25.1 +/- 20.1
  [Standarch]: 82W - 71L - 81D, Elo: 16.3 +/- 18.4
```