### PR TITLE
eval: count neutrals as walls on a slider ray

### DIFF
--- a/src/evaluation/base.rs
+++ b/src/evaluation/base.rs
@@ -2429,7 +2429,9 @@ fn line_congestion(
     let mut units = 0;
     // An enemy pawn walls a ray as surely as an own piece: it is usually
     // defended, and capturing it does not open the line the slider wanted.
-    let walls = |p: Piece| p.color() == own || p.piece_type() == PieceType::Pawn;
+    let walls = |p: Piece| {
+        p.color() == own || p.piece_type() == PieceType::Pawn || p.piece_type().is_neutral_type()
+    };
     if i + 1 < l.coords.len() {
         let d = l.coords[i + 1] - key;
         if d <= 2 && walls(Piece::from_packed(l.pieces[i + 1])) {


### PR DESCRIPTION
### Change:
A neutral piece a step or two down the line slows down piece development and blocks the attack.

### SPRT Results:
```
Final Summary:
  NEW: c6274d1 (2026-09-01, dirty)  vs  OLD: c6274d1 (2026-09-01)
  TC: 10+0.1 | Concurrency: 6 | Variants: 3 | Strength: 8 vs 8
  Material adjudication: Off | Max-ply adjudication: 1000 cp
  Elo: 21.07 +/- 10.22
  nElo: 25.01 +/- 12.09
  Games: 3170 | W: 1234 L: 1042 D: 894
  Pentanomial [1585 pairs] (0-2): 158, 320, 523, 340, 244
  LLR: 2.946  bounds [-2.94, 2.94] (normalized model, [0, 5])

Per-Variant Breakdown:
  [Confined_Classical]: 387W - 379L - 454D, Elo: 2.3 +/- 7.9
  [Obstocean]: 449W - 356L - 199D, Elo: 32.3 +/- 9.9
  [Triple_King_Maze]: 398W - 307L - 241D, Elo: 33.5 +/- 9.8
```
> [!NOTE]
> The comparison is kind of outdated since the engine recently updated like 2 hours ago. 